### PR TITLE
Add missing header

### DIFF
--- a/libursa/Utils.cpp
+++ b/libursa/Utils.cpp
@@ -1,6 +1,7 @@
 #include "Utils.h"
 
 #include <fstream>
+#include <iomanip>
 #include <random>
 #include <set>
 


### PR DESCRIPTION
It compiled well because of invisible dependency from `json.h` but it should be there.