### PR TITLE
Remove the copy constructor from Query class

### DIFF
--- a/libursa/Command.h
+++ b/libursa/Command.h
@@ -14,9 +14,9 @@ class SelectCommand {
     bool use_iterator;
 
    public:
-    SelectCommand(const Query &query, std::set<std::string> taints,
+    SelectCommand(Query &&query, std::set<std::string> taints,
                   bool use_iterator)
-        : query(query), taints(taints), use_iterator(use_iterator) {}
+        : query(std::move(query)), taints(taints), use_iterator(use_iterator) {}
     const Query &get_query() const { return query; }
     const std::set<std::string> &get_taints() const { return taints; }
     const bool iterator_requested() const { return use_iterator; }

--- a/libursa/Query.cpp
+++ b/libursa/Query.cpp
@@ -38,16 +38,16 @@ const std::vector<Query> &Query::as_queries() const {
 
 unsigned int Query::as_count() const { return count; }
 
-Query::Query(const QueryType &type, const std::vector<Query> &queries)
-    : type(type), queries(queries) {}
+Query::Query(const QueryType &type, std::vector<Query> &&queries)
+    : type(type), queries(std::move(queries)) {}
 
-Query::Query(unsigned int count, const std::vector<Query> &queries)
-    : type(QueryType::MIN_OF), count(count), queries(queries) {}
+Query::Query(unsigned int count, std::vector<Query> &&queries)
+    : type(QueryType::MIN_OF), count(count), queries(std::move(queries)) {}
 
 Query::Query(const QString &qstr)
     : type(QueryType::PRIMITIVE), value(qstr), queries() {}
 
-bool Query::operator==(Query other) const {
+bool Query::operator==(const Query &other) const {
     return type == other.type && value == other.value &&
            queries == other.queries;
 }
@@ -109,14 +109,14 @@ std::string Query::as_string_repr() const {
 
 Query q(const QString &qstr) { return Query(qstr); }
 
-Query q_and(const std::vector<Query> &queries) {
-    return Query(QueryType::AND, queries);
+Query q_and(std::vector<Query> &&queries) {
+    return Query(QueryType::AND, std::move(queries));
 }
 
-Query q_or(const std::vector<Query> &queries) {
-    return Query(QueryType::OR, queries);
+Query q_or(std::vector<Query> &&queries) {
+    return Query(QueryType::OR, std::move(queries));
 }
 
-Query q_min_of(unsigned int count, const std::vector<Query> &queries) {
-    return Query(count, queries);
+Query q_min_of(unsigned int count, std::vector<Query> &&queries) {
+    return Query(count, std::move(queries));
 }

--- a/libursa/Query.h
+++ b/libursa/Query.h
@@ -40,15 +40,17 @@ class QueryResult {
 class Query {
    public:
     explicit Query(const QString &qstr);
-    explicit Query(unsigned int count, const std::vector<Query> &queries);
-    explicit Query(const QueryType &type, const std::vector<Query> &queries);
+    explicit Query(unsigned int count, std::vector<Query> &&queries);
+    explicit Query(const QueryType &type, std::vector<Query> &&queries);
+    Query(const Query &other) = delete;
+    Query(Query &&other) = default;
 
     const std::vector<Query> &as_queries() const;
     const QString &as_value() const;
     unsigned int as_count() const;
     std::string as_string_repr() const;
     const QueryType &get_type() const;
-    bool operator==(Query other) const;
+    bool operator==(const Query &other) const;
 
    private:
     QueryType type;
@@ -58,7 +60,7 @@ class Query {
 };
 
 Query q(const QString &qstr);
-Query q_and(const std::vector<Query> &queries);
-Query q_or(const std::vector<Query> &queries);
-Query q_min_of(unsigned int count, const std::vector<Query> &queries);
+Query q_and(std::vector<Query> &&queries);
+Query q_or(std::vector<Query> &&queries);
+Query q_min_of(unsigned int count, std::vector<Query> &&queries);
 std::ostream &operator<<(std::ostream &os, const Query &query);

--- a/libursa/QueryParser.cpp
+++ b/libursa/QueryParser.cpp
@@ -295,12 +295,11 @@ Query transform(const parse_tree::node &n) {
 
         auto it = n.children.cbegin() + 1;
         std::vector<Query> subq;
-
         for (; it != n.children.cend(); ++it) {
             subq.emplace_back(transform(**it));
         }
 
-        return Query(counti, subq);
+        return Query(counti, std::move(subq));
     } else if (n.is<expression>()) {
         if (n.children.size() == 1) {
             return transform(*n.children[0]);
@@ -308,11 +307,15 @@ Query transform(const parse_tree::node &n) {
 
         auto &expr = n.children[1];
         if (expr->is<op_or>()) {
-            return Query(QueryType::OR, {transform(*n.children[0]),
-                                         transform(*n.children[2])});
+            std::vector<Query> opts;
+            opts.emplace_back(transform(*n.children[0]));
+            opts.emplace_back(transform(*n.children[2]));
+            return Query(QueryType::OR, std::move(opts));
         } else if (expr->is<op_and>()) {
-            return Query(QueryType::AND, {transform(*n.children[0]),
-                                          transform(*n.children[2])});
+            std::vector<Query> opts;
+            opts.emplace_back(transform(*n.children[0]));
+            opts.emplace_back(transform(*n.children[2]));
+            return Query(QueryType::AND, std::move(opts));
         } else {
             throw std::runtime_error("encountered unexpected expression");
         }


### PR DESCRIPTION
It may be prone to mistakes, and there is no reason to copy queries
around. Especially with coming query graphs, this operation may
turn out to be very expensive.