### PR TITLE
Adjustments in ursacli

### DIFF
--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -109,12 +109,17 @@ void UrsaClient::recv_res(zmq::socket_t &socket) {
         this->command_active = false;
         auto res = json::parse(res_str);
 
-        if (!this->quiet_mode) {
-            if (res["type"] == "error") {
-                spdlog::error(res["error"]["message"].get<std::string>());
-            } else {
-                std::cout << res.dump(4) << std::endl;
+        if (this->force_json) {
+            std::cout << res.dump(4) << std::endl;
+            return;
+        }
+
+        if (res["type"] == "select") {
+            for (auto &res : res["result"]["files"]) {
+                std::cout << res.get<std::string>() << std::endl;
             }
+	} else if (res["type"] == "error") {
+            spdlog::error(res["error"]["message"].get<std::string>());
         } else {
             std::cout << res.dump(4) << std::endl;
         }
@@ -179,10 +184,11 @@ int UrsaClient::start() {
 }
 
 UrsaClient::UrsaClient(std::string server_addr, std::string db_command,
-                       bool quiet_mode)
+                       bool quiet_mode, bool force_json)
     : server_addr(server_addr),
       db_command(db_command),
-      quiet_mode(quiet_mode) {}
+      quiet_mode(quiet_mode),
+      force_json(force_json) {}
 
 static void print_usage(const char *arg0) {
     spdlog::info("Usage: {} [server_addr] [args...]", arg0);
@@ -194,22 +200,28 @@ static void print_usage(const char *arg0) {
         "if not provided - interactive mode");
     spdlog::info(
         "    [-q]               silent mode, dump only command output");
+    spdlog::info(
+        "    [-j]               force JSON output everywhere");
 }
 
 int main(int argc, char *argv[]) {
     std::string server_addr = "tcp://localhost:9281";
     std::string db_command = "";
-    bool quiet_mode = false;
+    bool quiet_mode = !isatty(0);
+    bool force_json = false;
 
     int c;
 
-    while ((c = getopt(argc, argv, "hqc:")) != -1) {
+    while ((c = getopt(argc, argv, "hqjc:")) != -1) {
         switch (c) {
             case 'q':
                 quiet_mode = true;
                 break;
             case 'c':
                 db_command = optarg;
+                break;
+            case 'j':
+                force_json = true;
                 break;
             case 'h':
                 print_usage(argc >= 1 ? argv[0] : "ursacli");
@@ -229,6 +241,6 @@ int main(int argc, char *argv[]) {
         server_addr = argv[optind];
     }
 
-    UrsaClient client(server_addr, db_command, quiet_mode);
+    UrsaClient client(server_addr, db_command, quiet_mode, force_json);
     return client.start();
 }

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -118,7 +118,7 @@ void UrsaClient::recv_res(zmq::socket_t &socket) {
             for (auto &res : res["result"]["files"]) {
                 std::cout << res.get<std::string>() << std::endl;
             }
-	} else if (res["type"] == "error") {
+        } else if (res["type"] == "error") {
             spdlog::error(res["error"]["message"].get<std::string>());
         } else {
             std::cout << res.dump(4) << std::endl;
@@ -200,8 +200,7 @@ static void print_usage(const char *arg0) {
         "if not provided - interactive mode");
     spdlog::info(
         "    [-q]               silent mode, dump only command output");
-    spdlog::info(
-        "    [-j]               force JSON output everywhere");
+    spdlog::info("    [-j]               force JSON output everywhere");
 }
 
 int main(int argc, char *argv[]) {

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -115,7 +115,7 @@ void UrsaClient::recv_res(zmq::socket_t &socket) {
         }
 
         if (res["type"] == "select") {
-            for (auto &file : res["result"]["files"]) {
+            for (const auto &file : res["result"]["files"]) {
                 std::cout << file.get<std::string>() << std::endl;
             }
         } else if (res["type"] == "error") {

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -115,8 +115,8 @@ void UrsaClient::recv_res(zmq::socket_t &socket) {
         }
 
         if (res["type"] == "select") {
-            for (auto &res : res["result"]["files"]) {
-                std::cout << res.get<std::string>() << std::endl;
+            for (auto &file : res["result"]["files"]) {
+                std::cout << file.get<std::string>() << std::endl;
             }
         } else if (res["type"] == "error") {
             spdlog::error(res["error"]["message"].get<std::string>());

--- a/src/Client.h
+++ b/src/Client.h
@@ -13,6 +13,7 @@ private:
     std::string server_addr;
     std::string db_command;
     bool quiet_mode;
+    bool force_json;
 
     std::string server_version;
     std::string connection_id;
@@ -23,7 +24,7 @@ private:
     void recv_res(zmq::socket_t& socket);
 
 public:
-    UrsaClient(std::string server_addr, std::string db_command, bool quiet_mode);
+    UrsaClient(std::string server_addr, std::string db_command, bool quiet_mode, bool force_json);
     int start();
 };
 

--- a/src/Client.h
+++ b/src/Client.h
@@ -12,8 +12,8 @@ private:
 
     std::string server_addr;
     std::string db_command;
-    bool quiet_mode;
-    bool force_json;
+    bool is_interactive;
+    bool raw_json;
 
     std::string server_version;
     std::string connection_id;
@@ -24,7 +24,7 @@ private:
     void recv_res(zmq::socket_t& socket);
 
 public:
-    UrsaClient(std::string server_addr, std::string db_command, bool quiet_mode, bool force_json);
+    UrsaClient(std::string server_addr, std::string db_command, bool is_interactive, bool raw_json);
     int start();
 };
 


### PR DESCRIPTION
* Implied non-interactive (quiet) mode when input is not a TTY (e.g. `echo 'status' | ursacli`)
* Additional `-j` command line switch to turn off output postprocessing in the client (and always get the raw JSON response from server)
* By default, `select` queries will return a simple list of files (newline separated text)