### PR TITLE
Use readline for reading input in ursacli

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ target_clangformat_setup(ursadb_new)
 
 add_executable(ursacli src/Client.cpp)
 target_include_directories(ursacli PUBLIC ${CMAKE_SOURCE_DIR})
-target_link_libraries(ursacli ursa)
+target_link_libraries(ursacli ursa readline)
 target_enable_ipo(ursacli)
 target_clangformat_setup(ursacli)
 

--- a/src/Client.h
+++ b/src/Client.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <atomic>
+#include <optional>
 
 #include <zmq.hpp>
 
@@ -22,6 +23,8 @@ private:
     void status_worker();
     void init_conn(zmq::socket_t& socket);
     void recv_res(zmq::socket_t& socket);
+
+    std::optional<std::string> read_command(const std::string &prompt) const;
 
 public:
     UrsaClient(std::string server_addr, std::string db_command, bool is_interactive, bool raw_json);


### PR DESCRIPTION
Using readline allows terminal-like command editing, completion and history