### PR TITLE
Cleanup includes, remove unnecessary transitive dependencies

### DIFF
--- a/libursa/BitmapIndexBuilder.cpp
+++ b/libursa/BitmapIndexBuilder.cpp
@@ -1,10 +1,7 @@
 #include "BitmapIndexBuilder.h"
 
-#include <algorithm>
-#include <cassert>
 #include <fstream>
-#include <functional>
-#include <iostream>
+#include <stdexcept>
 
 #include "Utils.h"
 

--- a/libursa/BitmapIndexBuilder.h
+++ b/libursa/BitmapIndexBuilder.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/libursa/CMakeLists.txt
+++ b/libursa/CMakeLists.txt
@@ -10,6 +10,8 @@ add_library(
     Database.h
     DatabaseHandle.cpp
     DatabaseHandle.h
+    DatabaseName.cpp
+    DatabaseName.h
     DatabaseSnapshot.cpp
     DatabaseSnapshot.h
     DatasetBuilder.cpp

--- a/libursa/Core.h
+++ b/libursa/Core.h
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <optional>
+#include <string>
 #include <vector>
 
 using FileId = uint32_t;

--- a/libursa/Database.cpp
+++ b/libursa/Database.cpp
@@ -2,12 +2,12 @@
 
 #include <experimental/filesystem>
 #include <fstream>
-#include <iostream>
 #include <memory>
+#include <stdexcept>
 
+#include "Core.h"
 #include "ExclusiveFile.h"
 #include "Json.h"
-#include "Utils.h"
 #include "spdlog/spdlog.h"
 
 Database::Database(const std::string &fname, bool initialize)

--- a/libursa/Database.h
+++ b/libursa/Database.h
@@ -1,19 +1,14 @@
 #pragma once
 
 #include <experimental/filesystem>
-#include <iostream>
 #include <map>
-#include <random>
 #include <string>
 #include <vector>
 
 #include "DatabaseSnapshot.h"
-#include "DatasetBuilder.h"
 #include "OnDiskDataset.h"
 #include "OnDiskIterator.h"
-#include "Query.h"
 #include "Task.h"
-#include "Utils.h"
 
 class Database {
     fs::path db_name;

--- a/libursa/DatabaseHandle.h
+++ b/libursa/DatabaseHandle.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+#include <vector>
 #include <zmq.hpp>
 
 enum class NetAction : uint32_t {

--- a/libursa/DatabaseName.cpp
+++ b/libursa/DatabaseName.cpp
@@ -1,0 +1,27 @@
+#include "DatabaseName.h"
+
+#include "Utils.h"
+#include "spdlog/spdlog.h"
+
+DatabaseName DatabaseName::derive(const std::string &new_type,
+                                  const std::string &new_filename) const {
+    return DatabaseName(db_base, new_type, id, new_filename);
+}
+
+DatabaseName DatabaseName::derive_temporary() const {
+    std::string id = random_hex_string(8);
+    std::string fname = "temp." + id + ".ursa";
+    return DatabaseName(db_base, "temp", id, fname);
+}
+
+// TODO: convert all legacy names to DatbaseName.
+DatabaseName DatabaseName::parse(fs::path db_base, std::string name) {
+    auto first_dot = name.find('.');
+    auto second_dot = name.find('.', first_dot + 1);
+    if (second_dot == std::string::npos) {
+        throw std::runtime_error("Invalid dataset ID found");
+    }
+    std::string type = name.substr(0, first_dot);
+    std::string id = name.substr(first_dot + 1, second_dot - first_dot - 1);
+    return DatabaseName(db_base, type, id, name);
+}

--- a/libursa/DatabaseName.h
+++ b/libursa/DatabaseName.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <experimental/filesystem>
+
+// TODO get rid of this define
+namespace fs = std::experimental::filesystem;
+
+// Represents a name in the database. Usually a filename of the form
+// "type.id.dbname", for exmaple "set.23381d1f.db.ursa".
+// In case of manual rename, filename may not match this format.
+class DatabaseName {
+    fs::path db_base;
+    std::string type;
+    std::string id;
+    std::string filename;
+
+   public:
+    DatabaseName(fs::path db_base, std::string type, std::string id,
+                 std::string filename)
+        : db_base(db_base), type(type), id(id), filename(filename) {}
+
+    DatabaseName derive(const std::string &new_type,
+                        const std::string &new_filename) const;
+
+    DatabaseName derive_temporary() const;
+
+    std::string get_id() const { return id; }
+
+    fs::path get_full_path() const { return db_base / filename; }
+
+    std::string get_filename() const { return filename; }
+
+    // TODO: this method should not exist, convert all legacy name occurences
+    // to DatbaseName.
+    static DatabaseName parse(fs::path db_base, std::string name);
+};

--- a/libursa/DatabaseSnapshot.cpp
+++ b/libursa/DatabaseSnapshot.cpp
@@ -1,36 +1,12 @@
 #include "DatabaseSnapshot.h"
 
 #include <fstream>
+#include <stdexcept>
 
-#include "Database.h"
-#include "DatasetBuilder.h"
 #include "ExclusiveFile.h"
 #include "Indexer.h"
-#include "Json.h"
+#include "Utils.h"
 #include "spdlog/spdlog.h"
-
-DatabaseName DatabaseName::derive(const std::string &new_type,
-                                  const std::string &new_filename) const {
-    return DatabaseName(db_base, new_type, id, new_filename);
-}
-
-DatabaseName DatabaseName::derive_temporary() const {
-    std::string id = random_hex_string(8);
-    std::string fname = "temp." + id + ".ursa";
-    return DatabaseName(db_base, "temp", id, fname);
-}
-
-// TODO: convert all legacy names to DatbaseName.
-DatabaseName DatabaseName::parse(fs::path db_base, std::string name) {
-    auto first_dot = name.find('.');
-    auto second_dot = name.find('.', first_dot + 1);
-    if (second_dot == std::string::npos) {
-        throw std::runtime_error("Invalid dataset ID found");
-    }
-    std::string type = name.substr(0, first_dot);
-    std::string id = name.substr(first_dot + 1, second_dot - first_dot - 1);
-    return DatabaseName(db_base, type, id, name);
-}
 
 DatabaseSnapshot::DatabaseSnapshot(
     fs::path db_name, fs::path db_base,

--- a/libursa/DatabaseSnapshot.h
+++ b/libursa/DatabaseSnapshot.h
@@ -1,49 +1,18 @@
 #pragma once
 
 #include <experimental/filesystem>
-#include <iostream>
 #include <map>
+#include <set>
 #include <string>
 #include <vector>
 
 #include "DatabaseHandle.h"
+#include "DatabaseName.h"
+#include "OnDiskDataset.h"
+#include "OnDiskIterator.h"
 #include "Query.h"
 #include "ResultWriter.h"
 #include "Task.h"
-#include "Utils.h"
-
-class OnDiskDataset;
-class OnDiskIterator;
-
-// Represents a name in the database. Usually a filename of the form
-// "type.id.dbname", for exmaple "set.23381d1f.db.ursa".
-// In case of manual rename, filename may not match this format.
-class DatabaseName {
-    fs::path db_base;
-    std::string type;
-    std::string id;
-    std::string filename;
-
-   public:
-    DatabaseName(fs::path db_base, std::string type, std::string id,
-                 std::string filename)
-        : db_base(db_base), type(type), id(id), filename(filename) {}
-
-    DatabaseName derive(const std::string &new_type,
-                        const std::string &new_filename) const;
-
-    DatabaseName derive_temporary() const;
-
-    std::string get_id() const { return id; }
-
-    fs::path get_full_path() const { return db_base / filename; }
-
-    std::string get_filename() const { return filename; }
-
-    // TODO: this method should not exist, convert all legacy name occurences
-    // to DatbaseName.
-    static DatabaseName parse(fs::path db_base, std::string name);
-};
 
 // Represents immutable snapshot of database state.
 // Should never change, regardless of changes in real database.

--- a/libursa/DatasetBuilder.cpp
+++ b/libursa/DatasetBuilder.cpp
@@ -2,13 +2,12 @@
 
 #include <experimental/filesystem>
 #include <fstream>
-#include <iostream>
 #include <set>
 
 #include "BitmapIndexBuilder.h"
+#include "FlatIndexBuilder.h"
 #include "Json.h"
 #include "MemMap.h"
-#include "OnDiskDataset.h"
 #include "Utils.h"
 
 DatasetBuilder::DatasetBuilder(BuilderType builder_type,

--- a/libursa/DatasetBuilder.h
+++ b/libursa/DatasetBuilder.h
@@ -4,8 +4,10 @@
 #include <vector>
 
 #include "Core.h"
-#include "FlatIndexBuilder.h"
-#include "Utils.h"
+#include "IndexBuilder.h"
+
+// TODO get rid of this define
+namespace fs = std::experimental::filesystem;
 
 class DatasetBuilder {
    public:

--- a/libursa/FlatIndexBuilder.cpp
+++ b/libursa/FlatIndexBuilder.cpp
@@ -1,10 +1,7 @@
 #include "FlatIndexBuilder.h"
 
 #include <algorithm>
-#include <cassert>
 #include <fstream>
-#include <functional>
-#include <iostream>
 
 #include "Utils.h"
 

--- a/libursa/Indexer.h
+++ b/libursa/Indexer.h
@@ -2,6 +2,8 @@
 
 #include <string>
 
+#include "DatabaseSnapshot.h"
+#include "DatasetBuilder.h"
 #include "OnDiskDataset.h"
 
 class Indexer {

--- a/libursa/MemMap.cpp
+++ b/libursa/MemMap.cpp
@@ -2,11 +2,7 @@
 
 #include <fcntl.h>
 #include <sys/mman.h>
-#include <sys/stat.h>
-#include <sys/types.h>
-
-#include <cstring>
-#include <iostream>
+#include <unistd.h>
 
 MemMap::MemMap(const std::string &fname) : fname(fname) {
     fd = open(fname.c_str(), O_RDONLY, (mode_t)0600);

--- a/libursa/MemMap.h
+++ b/libursa/MemMap.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <unistd.h>
-
-#include <cstddef>
 #include <cstdint>
 #include <stdexcept>
 #include <string>

--- a/libursa/OnDiskDataset.cpp
+++ b/libursa/OnDiskDataset.cpp
@@ -4,7 +4,7 @@
 #include <fstream>
 #include <set>
 
-#include "Database.h"
+#include "DatabaseName.h"
 #include "Json.h"
 #include "Query.h"
 

--- a/libursa/OnDiskDataset.h
+++ b/libursa/OnDiskDataset.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <optional>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -11,8 +12,6 @@
 #include "QueryResult.h"
 #include "ResultWriter.h"
 #include "Task.h"
-
-class OnDiskIndex;
 
 class OnDiskDataset {
     std::string name;

--- a/libursa/OnDiskFileIndex.cpp
+++ b/libursa/OnDiskFileIndex.cpp
@@ -1,4 +1,6 @@
-#include "OnDiskIndex.h"
+#include "OnDiskFileIndex.h"
+
+#include <fstream>
 
 void OnDiskFileIndex::generate_namecache_file() {
     std::ofstream of;

--- a/libursa/OnDiskFileIndex.h
+++ b/libursa/OnDiskFileIndex.h
@@ -1,15 +1,15 @@
 #pragma once
 
-#include <fstream>
+#include <experimental/filesystem>
+#include <functional>
 #include <optional>
 #include <string>
-#include <vector>
 
 #include "Core.h"
-#include "Database.h"
-#include "Query.h"
 #include "RawFile.h"
-#include "Task.h"
+
+// TODO get rid of this define
+namespace fs = std::experimental::filesystem;
 
 class OnDiskFileIndex {
     uint64_t file_count;

--- a/libursa/OnDiskIndex.cpp
+++ b/libursa/OnDiskIndex.cpp
@@ -7,6 +7,7 @@
 
 #include "FeatureFlags.h"
 #include "Query.h"
+#include "QueryGraph.h"
 #include "Utils.h"
 #include "spdlog/spdlog.h"
 

--- a/libursa/OnDiskIndex.cpp
+++ b/libursa/OnDiskIndex.cpp
@@ -3,7 +3,6 @@
 #include <algorithm>
 #include <cstring>
 #include <fstream>
-#include <iostream>
 
 #include "FeatureFlags.h"
 #include "Query.h"

--- a/libursa/OnDiskIndex.h
+++ b/libursa/OnDiskIndex.h
@@ -1,18 +1,15 @@
 #pragma once
 
-#include <fstream>
 #include <string>
 #include <vector>
 
 #include "Core.h"
-#include "Database.h"
-#include "Query.h"
+#include "QueryResult.h"
 #include "RawFile.h"
 #include "Task.h"
 #include "Utils.h"
 
 struct IndexMergeHelper;
-class QueryResult;
 
 class OnDiskIndex {
     uint64_t index_size;

--- a/libursa/OnDiskIterator.cpp
+++ b/libursa/OnDiskIterator.cpp
@@ -1,5 +1,7 @@
 #include "OnDiskIterator.h"
 
+#include <fstream>
+
 #include "Json.h"
 
 void write_itermeta(DatabaseName target, uint64_t byte_offset,

--- a/libursa/OnDiskIterator.h
+++ b/libursa/OnDiskIterator.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <fstream>
-
-#include "Database.h"
+#include "DatabaseName.h"
 
 class OnDiskIterator {
     DatabaseName name;

--- a/libursa/Query.h
+++ b/libursa/Query.h
@@ -1,12 +1,10 @@
 #pragma once
 
-#include <algorithm>
-#include <memory>
 #include <ostream>
 #include <string>
 #include <vector>
 
-#include "QueryGraph.h"
+#include "Core.h"
 
 enum QueryType { PRIMITIVE = 1, AND = 2, OR = 3, MIN_OF = 4 };
 

--- a/libursa/QueryParser.cpp
+++ b/libursa/QueryParser.cpp
@@ -4,7 +4,6 @@
 
 #include "QueryParser.h"
 
-#include <iostream>
 #include <string>
 #include <type_traits>
 

--- a/libursa/QueryParser.cpp
+++ b/libursa/QueryParser.cpp
@@ -8,10 +8,9 @@
 #include <string>
 #include <type_traits>
 
-#include "Command.h"
 #include "Core.h"
+#include "FeatureFlags.h"
 #include "Query.h"
-#include "QueryGraph.h"
 #include "Version.h"
 #include "pegtl/pegtl.hpp"
 #include "pegtl/pegtl/contrib/abnf.hpp"

--- a/libursa/QueryParser.h
+++ b/libursa/QueryParser.h
@@ -1,6 +1,5 @@
 #pragma once
 
 #include "Command.h"
-#include "FeatureFlags.h"
 
 Command parse_command(const std::string &s);

--- a/libursa/QueryResult.cpp
+++ b/libursa/QueryResult.cpp
@@ -1,5 +1,7 @@
 #include "QueryResult.h"
 
+#include <algorithm>
+
 void QueryResult::do_or(const QueryResult &other) {
     if (this->is_everything() || other.is_everything()) {
         has_everything = true;

--- a/libursa/QueryResult.h
+++ b/libursa/QueryResult.h
@@ -1,9 +1,5 @@
 #pragma once
 
-#include <algorithm>
-#include <memory>
-#include <ostream>
-#include <string>
 #include <vector>
 
 #include "Core.h"

--- a/libursa/RawFile.h
+++ b/libursa/RawFile.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <fstream>
-
 class RawFile {
     int fd;
 

--- a/libursa/Responses.h
+++ b/libursa/Responses.h
@@ -1,11 +1,11 @@
 #pragma once
 
+#include <set>
 #include <string>
 #include <vector>
 
 #include "Core.h"
 #include "Json.h"
-#include "Utils.h"
 
 struct TaskEntry {
     std::string id;

--- a/libursa/Utils.h
+++ b/libursa/Utils.h
@@ -12,6 +12,8 @@
 using TrigramCallback = std::function<void(TriGram)>;
 using TrigramGenerator = void (*)(const uint8_t *mem, size_t size,
                                   TrigramCallback callback);
+
+// TODO get rid of this define
 namespace fs = std::experimental::filesystem;
 
 std::string_view get_version_string();

--- a/src/Daemon.cpp
+++ b/src/Daemon.cpp
@@ -227,7 +227,7 @@ int main(int argc, char *argv[]) {
         std::string bind_address = "tcp://127.0.0.1:9281";
 
         if (argc > 3) {
-            std::cout << "Too many command line arguments." << std::endl;
+            spdlog::error("Too many command line arguments.");
         } else if (argc == 3) {
             bind_address = std::string(argv[2]);
         }

--- a/src/NewDatabase.cpp
+++ b/src/NewDatabase.cpp
@@ -1,6 +1,5 @@
 #include <array>
 #include <fstream>
-#include <iostream>
 #include <list>
 #include <stack>
 #include <utility>

--- a/src/Tests.cpp
+++ b/src/Tests.cpp
@@ -5,6 +5,8 @@
 
 #include "catch/Catch.h"
 #include "libursa/BitmapIndexBuilder.h"
+#include "libursa/Database.h"
+#include "libursa/DatabaseSnapshot.h"
 #include "libursa/FlatIndexBuilder.h"
 #include "libursa/IndexBuilder.h"
 #include "libursa/OnDiskDataset.h"


### PR DESCRIPTION
Right now basically everything includes everything else.
This slows down compilation, because every small header file change will cause
a recompilation of most of the project. I've removed (most) of the unnecessary
dependencies with this PR, but there are some design problems - for example
Core.h and Utils.h files that are a thrash cans for random snippets of code
used by everything.
