### PR TITLE
Implement a naive graph pruning algorithm

### DIFF
--- a/libursa/QString.cpp
+++ b/libursa/QString.cpp
@@ -36,7 +36,9 @@ QToken QToken::wildcard() {
     return QToken(std::move(options), 0, QTokenType::WILDCARD);
 }
 
-std::vector<uint8_t> QToken::possible_values() const { return opts_; }
+const std::vector<uint8_t> &QToken::possible_values() const { return opts_; }
+
+uint64_t QToken::num_possible_values() const { return opts_.size(); }
 
 bool QToken::operator==(const QToken &other) const {
     return opts_ == other.opts_;


### PR DESCRIPTION
Constants in OnDiskIndex.cpp explain it all:

```
// Maximum number of possible values for the edge to be considered.
// If token has more than MAX_EDGE possible values, it will never start
// or end a subgraph. This is to avoid starting a subquery with `??`.
constexpr uint32_t MAX_EDGE = 16;

// Maximum number of possible values for ngram to be considered. If ngram
// has more than MAX_NGRAM possible values, it won't be included in the
// graph and the graph will be split into one or more subgraphs.
constexpr uint32_t MAX_NGRAM = 256 * 256;
```

Oh the one hand, this is far from perfect. For example there is a **huge**
performance difference between:

```
BB CC ?? DD ?? EE FF
```

And

```
A? B? C? ?? D? E? F?
```

The first one will execute in miliseconds, while the second one will take a
long time. Fair enough, the second is literally the worst case (I can't think
of a more complex expression that won't be rejected), but they both have 4 `?`s
in the worst ngram, while one runs in 233ms and the other in 4135ms.

On the other hand, they all finish running successfully, and I guess that's
what matters in the end (no DB crashes).