### PR TITLE
Implement alternatives in the query syntax

### DIFF
--- a/libursa/OnDiskIndex.cpp
+++ b/libursa/OnDiskIndex.cpp
@@ -107,6 +107,8 @@ bool OnDiskIndex::internal_expand(QString::const_iterator qit, uint8_t *out,
                     j += 0x10;
                 }
                 break;
+            default:
+                throw std::runtime_error("unknown token type");
         }
     } while (true);
 }

--- a/libursa/QString.cpp
+++ b/libursa/QString.cpp
@@ -36,6 +36,10 @@ QToken QToken::wildcard() {
     return QToken(std::move(options), 0, QTokenType::WILDCARD);
 }
 
+QToken QToken::with_values(std::vector<uint8_t> &&values) {
+    return QToken(std::move(values), 0, QTokenType::EXPLICIT);
+}
+
 const std::vector<uint8_t> &QToken::possible_values() const { return opts_; }
 
 uint64_t QToken::num_possible_values() const { return opts_.size(); }

--- a/libursa/QString.h
+++ b/libursa/QString.h
@@ -8,7 +8,8 @@ enum class QTokenType {
     CHAR = 1,       // normal byte e.g. \xAA
     WILDCARD = 2,   // full wildcard \x??
     HWILDCARD = 3,  // high wildcard e.g. \x?A
-    LWILDCARD = 4   // low wildcard e.g. \xA?
+    LWILDCARD = 4,  // low wildcard e.g. \xA?
+    EXPLICIT = 5    // explicit option list. Not understood by legacy methods.
 };
 
 // Represents a single token in a query. For example AA, A?, ?? or (AA | BB).
@@ -41,6 +42,9 @@ class QToken {
 
     // Creates a wildcard token ({??}).
     static QToken wildcard();
+
+    // Creates a wildcard with exactly given option list.
+    static QToken with_values(std::vector<uint8_t> &&values);
 
     // Returns a list of possible values for this token.
     const std::vector<uint8_t> &possible_values() const;

--- a/libursa/Query.cpp
+++ b/libursa/Query.cpp
@@ -74,8 +74,10 @@ std::string Query::as_string_repr() const {
             out += "\\x?" + std::to_string(token.val());
         } else if (token.type() == QTokenType::HWILDCARD) {
             out += "\\x" + std::to_string(token.val() >> 4) + "?";
-        } else {
+        } else if (token.type() == QTokenType::CHAR) {
             out += token.val();
+        } else {
+            throw std::runtime_error("Unknown token type");
         }
     }
 

--- a/src/Tests.cpp
+++ b/src/Tests.cpp
@@ -98,6 +98,28 @@ TEST_CASE("select hexstring with low wildcard", "[queryparser]") {
     REQUIRE(cmd.get_query() == q(std::move(expect)));
 }
 
+TEST_CASE("select hexstring with explicit options", "[queryparser]") {
+    QString expect;
+    expect.emplace_back(std::move(QToken::single(0x4d)));
+    expect.emplace_back(std::move(QToken::with_values({0x51, 0x52})));
+    expect.emplace_back(std::move(QToken::single(0x4d)));
+
+    auto cmd = parse<SelectCommand>("select { 4d (51 | 52) 4d };");
+    REQUIRE(cmd.get_query() == q(std::move(expect)));
+}
+
+TEST_CASE("select hexstring with mixed explicit options", "[queryparser]") {
+    QString expect;
+    expect.emplace_back(std::move(QToken::single(0x4d)));
+    expect.emplace_back(std::move(QToken::with_values(
+        {0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59, 0x5a, 0x5b,
+         0x5c, 0x5d, 0x5e, 0x5f, 0x70})));
+    expect.emplace_back(std::move(QToken::single(0x4d)));
+
+    auto cmd = parse<SelectCommand>("select { 4d (5? | 70) 4d };");
+    REQUIRE(cmd.get_query() == q(std::move(expect)));
+}
+
 TEST_CASE("select literal", "[queryparser]") {
     auto cmd = parse<SelectCommand>("select \"MSM\";");
     REQUIRE(cmd.get_query() == q(std::move(mqs("MSM"))));


### PR DESCRIPTION
For example {aa bb (11 | 22) cc dd}

fixes #65