### PR TITLE
Refactor networking

### DIFF
--- a/libursa/DatabaseHandle.cpp
+++ b/libursa/DatabaseHandle.cpp
@@ -8,27 +8,26 @@ DatabaseHandle::DatabaseHandle(zmq::socket_t *worker) : worker(worker) {}
 
 [[nodiscard]] bool DatabaseHandle::request_dataset_lock(
     const std::vector<std::string> &ds_names) const {
-    s_send_val<NetAction>(*worker, NetAction::DatasetLockReq, ZMQ_SNDMORE);
+    s_send<NetAction>(worker, NetAction::DatasetLockReq, ZMQ_SNDMORE);
 
     for (const auto &ds_name : ds_names) {
-        s_send(*worker, "", ZMQ_SNDMORE);
-        s_send(*worker, ds_name, ZMQ_SNDMORE);
+        s_send_padding(worker, ZMQ_SNDMORE);
+        s_send(worker, ds_name, ZMQ_SNDMORE);
     }
 
-    s_send(*worker, "", ZMQ_SNDMORE);
-    s_send(*worker, "");
+    s_send_padding(worker, ZMQ_SNDMORE);
+    s_send_padding(worker);
 
-    return s_recv_val<NetLockResp>(*worker) == NetLockResp::LockOk;
+    return s_recv<NetLockResp>(worker) == NetLockResp::LockOk;
 }
 
 [[nodiscard]] bool DatabaseHandle::request_iterator_lock(
     const std::string &it_name) const {
-    s_send_val<NetAction>(*worker, NetAction::IteratorLockReq, ZMQ_SNDMORE);
+    s_send(worker, NetAction::IteratorLockReq, ZMQ_SNDMORE);
+    s_send_padding(worker, ZMQ_SNDMORE);
+    s_send(worker, it_name, ZMQ_SNDMORE);
 
-    s_send(*worker, "", ZMQ_SNDMORE);
-    s_send(*worker, it_name, ZMQ_SNDMORE);
+    s_send_padding(worker);
 
-    s_send(*worker, "");
-
-    return s_recv_val<NetLockResp>(*worker) == NetLockResp::LockOk;
+    return s_recv<NetLockResp>(worker) == NetLockResp::LockOk;
 }

--- a/libursa/ZHelpers.cpp
+++ b/libursa/ZHelpers.cpp
@@ -1,13 +1,46 @@
 #include "ZHelpers.h"
 
-std::string s_recv(zmq::socket_t &socket) {
+void s_send_raw(zmq::socket_t *socket, std::string_view payload,
+                int flags = 0) {
+    zmq::message_t message(payload.size());
+    ::memcpy(message.data(), payload.data(), payload.size());
+    bool ok{socket->send(message, flags)};
+    if (!ok) {
+        throw std::runtime_error("zmq socket: send failed");
+    }
+}
+
+std::string s_recv_raw(zmq::socket_t *socket) {
     zmq::message_t message;
-    socket.recv(&message);
+    bool ok{socket->recv(&message)};
+    if (!ok) {
+        throw std::runtime_error("zmq socket: recv failed");
+    }
     return std::string(static_cast<char *>(message.data()), message.size());
 }
 
-bool s_send(zmq::socket_t &socket, const std::string &string, int flags) {
-    zmq::message_t message(string.size());
-    memcpy(message.data(), string.data(), string.size());
-    return socket.send(message, flags);
+void s_send_padding(zmq::socket_t *socket, int flags) {
+    s_send_raw(socket, std::string_view{}, flags);
+}
+
+void s_recv_padding(zmq::socket_t *socket) {
+    auto resp{s_recv<std::string>(socket)};
+    if (!resp.empty()) {
+        throw std::runtime_error("Expected zero-sized frame");
+    }
+}
+
+template <>
+void s_send(zmq::socket_t *socket, const std::string &value, int flags) {
+    s_send_raw(socket, std::string_view(value), flags);
+}
+
+template <>
+std::string s_recv(zmq::socket_t *socket) {
+    return s_recv_raw(socket);
+}
+
+template <>
+void s_send(zmq::socket_t *socket, const std::string_view &value, int flags) {
+    s_send_raw(socket, value, flags);
 }

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -35,7 +35,7 @@ void UrsaClient::status_worker() {
         }
 
         wait_time = 0;
-        s_send(socket, "status;");
+        s_send<std::string_view>(&socket, "status;");
         std::string res_str;
         uint64_t retries = 0;
 
@@ -46,7 +46,7 @@ void UrsaClient::status_worker() {
                     "progress for more than 30 seconds.");
             }
 
-            res_str = s_recv(socket);
+            res_str = s_recv<std::string>(&socket);
             retries++;
         }
 
@@ -69,8 +69,8 @@ void UrsaClient::status_worker() {
 }
 
 void UrsaClient::init_conn(zmq::socket_t &socket) {
-    s_send(socket, "ping;");
-    auto res_str = s_recv(socket);
+    s_send<std::string_view>(&socket, "ping;");
+    auto res_str = s_recv<std::string>(&socket);
 
     if (res_str.empty()) {
         throw std::runtime_error("Failed to connect to the database!");
@@ -100,7 +100,7 @@ void UrsaClient::recv_res(zmq::socket_t &socket) {
     this->wait_time = 0;
 
     while (this->command_active) {
-        auto res_str = s_recv(socket);
+        auto res_str = s_recv<std::string>(&socket);
 
         if (res_str.empty()) {
             continue;
@@ -132,7 +132,7 @@ static void s_send_cmd(zmq::socket_t &socket, std::string cmd) {
         cmd = cmd + ";";
     }
 
-    s_send(socket, cmd);
+    s_send(&socket, cmd);
 }
 
 int UrsaClient::start() {


### PR DESCRIPTION
* Remove `s_send_val` and replace with uniform interface - `s_send` / `s_recv`
* Introduce `s_send/recv_raw` for raw access to socket - generally shouldn't be used for in code
* Introduce helper function `s_send/recv_padding` for handling padding messages
* Allow only simple types to be sent over the socket (with the possibility to implement serialization of more types)
* Make s_send/s_recv interface compatible with Google style guide (pointer instead of reference)