### PR TITLE
Add a nocheck modifier for index commend

### DIFF
--- a/libursa/Command.h
+++ b/libursa/Command.h
@@ -25,15 +25,17 @@ class SelectCommand {
 };
 
 class IndexCommand {
-    std::vector<std::string> paths;
-    std::vector<IndexType> types;
+    std::vector<std::string> paths_;
+    std::vector<IndexType> types_;
+    bool ensure_unique_;
 
    public:
     IndexCommand(const std::vector<std::string> &paths,
-                 const std::vector<IndexType> &types)
-        : paths(paths), types(types) {}
-    const std::vector<std::string> &get_paths() const { return paths; }
-    const std::vector<IndexType> &get_index_types() const { return types; }
+                 const std::vector<IndexType> &types, bool ensure_unique)
+        : paths_(paths), types_(types), ensure_unique_(ensure_unique) {}
+    const std::vector<std::string> &get_paths() const { return paths_; }
+    const std::vector<IndexType> &get_index_types() const { return types_; }
+    const bool ensure_unique() const { return ensure_unique_; }
 };
 
 class IteratorPopCommand {
@@ -48,15 +50,19 @@ class IteratorPopCommand {
 };
 
 class IndexFromCommand {
-    std::string path_list_fname;
-    std::vector<IndexType> types;
+    std::string path_list_fname_;
+    std::vector<IndexType> types_;
+    bool ensure_unique_;
 
    public:
     IndexFromCommand(const std::string &path_list_fname,
-                     const std::vector<IndexType> &types)
-        : path_list_fname(path_list_fname), types(types) {}
-    const std::string &get_path_list_fname() const { return path_list_fname; }
-    const std::vector<IndexType> &get_index_types() const { return types; }
+                     const std::vector<IndexType> &types, bool ensure_unique)
+        : path_list_fname_(path_list_fname),
+          types_(types),
+          ensure_unique_(ensure_unique) {}
+    const std::string &get_path_list_fname() const { return path_list_fname_; }
+    const std::vector<IndexType> &get_index_types() const { return types_; }
+    const bool ensure_unique() const { return ensure_unique_; }
 };
 
 class ReindexCommand {

--- a/libursa/DatabaseSnapshot.h
+++ b/libursa/DatabaseSnapshot.h
@@ -27,8 +27,7 @@ class DatabaseSnapshot {
     size_t max_memory_size;
     DatabaseHandle db_handle;
 
-    void build_new_target_list(const std::vector<std::string> &filepaths,
-                               std::vector<std::string> *targets) const;
+    void find_all_indexed_files(std::set<std::string> *indexed) const;
     void build_target_list(const std::string &filepath,
                            const std::set<std::string> &existing_files,
                            std::vector<std::string> *targets) const;
@@ -64,8 +63,28 @@ class DatabaseSnapshot {
                        std::vector<std::string> *out,
                        uint64_t *out_iterator_position,
                        uint64_t *out_iterator_files) const;
-    void index_path(Task *task, const std::vector<IndexType> &types,
-                    const std::vector<std::string> &filepaths) const;
+
+    // Recursively indexes files under paths in `filepaths`. Ensures that no
+    // file will be indexed twice - this may be a very memory-heavy operation
+    void recursive_index_paths(Task *task, const std::vector<IndexType> &types,
+                               const std::vector<std::string> &filepaths) const;
+
+    // Recursively indexes files under paths in `filepaths`. Does not check for
+    // duplicated files, which makes if faster, but also more dangerous.
+    void force_recursive_index_paths(
+        Task *task, const std::vector<IndexType> &types,
+        const std::vector<std::string> &filepaths) const;
+
+    // Indexes files with given paths. Ensures that no file will be indexed
+    // twice - this may be a very memory-heavy operation.
+    void index_files(Task *task, const std::vector<IndexType> &types,
+                     const std::vector<std::string> &filepaths) const;
+
+    // Indexes files with given paths. Does not check for
+    // duplicated files, which makes if faster, but also more dangerous.
+    void force_index_files(Task *task, const std::vector<IndexType> &types,
+                           const std::vector<std::string> &filepaths) const;
+
     void reindex_dataset(Task *task, const std::vector<IndexType> &types,
                          const std::string &dataset_name) const;
     void execute(const Query &query, const std::set<std::string> &taints,

--- a/libursa/QueryParser.cpp
+++ b/libursa/QueryParser.cpp
@@ -15,6 +15,7 @@
 #include "pegtl/pegtl/contrib/abnf.hpp"
 #include "pegtl/pegtl/contrib/parse_tree.hpp"
 #include "pegtl/pegtl/contrib/unescape.hpp"
+#include "spdlog/spdlog.h"
 
 using namespace tao::TAO_PEGTL_NAMESPACE;  // NOLINT
 
@@ -46,6 +47,7 @@ struct from_token : TAO_PEGTL_STRING("from") {};
 struct list_token : TAO_PEGTL_STRING("list") {};
 struct min_token : TAO_PEGTL_STRING("min") {};
 struct of_token : TAO_PEGTL_STRING("of") {};
+struct nocheck_token : TAO_PEGTL_STRING("nocheck") {};
 struct into_token : TAO_PEGTL_STRING("into") {};
 struct iterator_token : TAO_PEGTL_STRING("iterator") {};
 struct pop_token : TAO_PEGTL_STRING("pop") {};
@@ -165,14 +167,15 @@ struct iterator_pop: seq<pop_token, plus<space>, number> {};
 struct index_type : sor<gram3_token, hash4_token, text4_token, wide8_token> {};
 struct paths_construct : list<string_like, space> {};
 struct index_type_list : seq<open_square, opt<list<index_type, comma>>, close_square> {};
-struct index_with_construct : seq<with_token, star<space>, index_type_list> {};
+struct index_with_construct : seq<star<space>, with_token, star<space>, index_type_list> {};
+struct nocheck_construct : seq<star<space>, nocheck_token> {};
 struct from_list_construct : seq<from_token, plus<space>, list_token, plus<space>, string_like> {};
 
 // commands
 struct select : seq<select_token, opt<with_taints_construct>, opt<into_iterator_construct>, select_body> {};
 struct dataset : seq<dataset_token, star<space>, plaintext, star<space>, dataset_operation> {};
 struct iterator : seq<iterator_token, star<space>, plaintext, star<space>, iterator_pop> {};
-struct index : seq<index_token, star<space>, sor<paths_construct, from_list_construct>, star<space>, opt<index_with_construct>> {};
+struct index : seq<index_token, star<space>, sor<paths_construct, from_list_construct>, opt<index_with_construct>, opt<nocheck_construct>> {};
 struct reindex : seq<reindex_token, star<space>, string_like, star<space>, index_with_construct> {};
 struct compact : seq<compact_token, star<space>, sor<all_token, smart_token>> {};
 struct status : seq<status_token> {};
@@ -188,6 +191,7 @@ template <typename> struct store : std::false_type {};
 template <> struct store<plaintext> : std::true_type {};
 template <> struct store<with_taints_token> : std::true_type {};
 template <> struct store<into_token> : std::true_type {};
+template <> struct store<nocheck_construct> : std::true_type {};
 template <> struct store<wide_plaintext> : std::true_type {};
 template <> struct store<op_and> : parse_tree::remove_content {};
 template <> struct store<op_or> : parse_tree::remove_content {};
@@ -446,9 +450,14 @@ Command transform_command(const parse_tree::node &n) {
 
         std::vector<std::string> paths;
         std::vector<IndexType> types = default_index_types();
+        bool ensure_unique = true;
 
-        if (n.children.size() == 2) {
-            types = transform_index_types(*n.children[1]);
+        for (size_t mod = 1; mod < n.children.size(); mod++) {
+            if (n.children[mod]->is<nocheck_construct>()) {
+                ensure_unique = false;
+            } else if (n.children[mod]->is<index_type_list>()) {
+                types = transform_index_types(*n.children[1]);
+            }
         }
 
         if (target_n->is<paths_construct>()) {
@@ -457,10 +466,10 @@ Command transform_command(const parse_tree::node &n) {
                 paths.push_back(transform_string(**it));
             }
 
-            return Command(IndexCommand(paths, types));
+            return Command(IndexCommand(paths, types, ensure_unique));
         } else if (target_n->is<from_list_construct>()) {
             std::string list_file = transform_string(*target_n->children[0]);
-            return Command(IndexFromCommand(list_file, types));
+            return Command(IndexFromCommand(list_file, types, ensure_unique));
         } else {
             throw std::runtime_error("unexpected first node in index");
         }

--- a/libursa/QueryParser.cpp
+++ b/libursa/QueryParser.cpp
@@ -15,7 +15,6 @@
 #include "pegtl/pegtl/contrib/abnf.hpp"
 #include "pegtl/pegtl/contrib/parse_tree.hpp"
 #include "pegtl/pegtl/contrib/unescape.hpp"
-#include "spdlog/spdlog.h"
 
 using namespace tao::TAO_PEGTL_NAMESPACE;  // NOLINT
 

--- a/src/Benchmark.cpp
+++ b/src/Benchmark.cpp
@@ -56,7 +56,7 @@ uint64_t benchmark_index(int files, int file_size) {
         auto snap = db.snapshot();
         std::vector<IndexType> index_types = {IndexType::GRAM3};
         Task *task = db.allocate_task();
-        snap.index_path(task, index_types, {test_path});
+        snap.recursive_index_paths(task, index_types, {test_path});
         db.commit_task(task->id);
     });
     close(fd);

--- a/src/Daemon.cpp
+++ b/src/Daemon.cpp
@@ -88,14 +88,24 @@ Response execute_command(const IndexFromCommand &cmd, Task *task,
         }
     }
 
-    snap->index_path(task, cmd.get_index_types(), paths);
+    if (cmd.ensure_unique()) {
+        snap->index_files(task, cmd.get_index_types(), paths);
+    } else {
+        snap->force_index_files(task, cmd.get_index_types(), paths);
+    }
 
     return Response::ok();
 }
 
 Response execute_command(const IndexCommand &cmd, Task *task,
                          const DatabaseSnapshot *snap) {
-    snap->index_path(task, cmd.get_index_types(), cmd.get_paths());
+    if (cmd.ensure_unique()) {
+        snap->recursive_index_paths(task, cmd.get_index_types(),
+                                    cmd.get_paths());
+    } else {
+        snap->force_recursive_index_paths(task, cmd.get_index_types(),
+                                          cmd.get_paths());
+    }
 
     return Response::ok();
 }

--- a/src/Tests.cpp
+++ b/src/Tests.cpp
@@ -218,6 +218,7 @@ TEST_CASE("index command with default types", "[queryparser]") {
     auto cmd = parse<IndexCommand>("index \"cat\";");
     REQUIRE(cmd.get_paths() == std::vector<std::string>{"cat"});
     REQUIRE(cmd.get_index_types() == std::vector{IndexType::GRAM3});
+    REQUIRE(cmd.ensure_unique() == true);
 }
 
 TEST_CASE("index command with type override", "[queryparser]") {
@@ -225,6 +226,12 @@ TEST_CASE("index command with type override", "[queryparser]") {
     REQUIRE(cmd.get_paths() == std::vector<std::string>{"cat"});
     REQUIRE(cmd.get_index_types() ==
             std::vector{IndexType::TEXT4, IndexType::WIDE8});
+}
+
+TEST_CASE("index command with nocheck", "[queryparser]") {
+    auto cmd = parse<IndexCommand>("index \"cat\" nocheck;");
+    REQUIRE(cmd.get_paths() == std::vector<std::string>{"cat"});
+    REQUIRE(cmd.ensure_unique() == false);
 }
 
 TEST_CASE("index command with empty type override", "[queryparser]") {
@@ -252,12 +259,19 @@ TEST_CASE("index from command", "[queryparser]") {
     auto cmd = parse<IndexFromCommand>("index from list \"aaa\";");
     REQUIRE(cmd.get_path_list_fname() == "aaa");
     REQUIRE(cmd.get_index_types() == std::vector{IndexType::GRAM3});
+    REQUIRE(cmd.ensure_unique() == true);
 }
 
 TEST_CASE("index from command with type override", "[queryparser]") {
     auto cmd = parse<IndexFromCommand>("index from list \"aaa\" with [hash4];");
     REQUIRE(cmd.get_path_list_fname() == "aaa");
     REQUIRE(cmd.get_index_types() == std::vector{IndexType::HASH4});
+}
+
+TEST_CASE("index from command with nocheck", "[queryparser]") {
+    auto cmd = parse<IndexFromCommand>("index from list \"aaa\" nocheck;");
+    REQUIRE(cmd.get_path_list_fname() == "aaa");
+    REQUIRE(cmd.ensure_unique() == false);
 }
 
 TEST_CASE("dataset.taint command", "[queryparser]") {
@@ -610,10 +624,10 @@ TEST_CASE("Query end2end test", "[e2e_test]") {
     DatabaseSnapshot snap = db.snapshot();
 
     Task *task = db.allocate_task();
-    db.snapshot().index_path(task,
-                             {IndexType::GRAM3, IndexType::HASH4,
-                              IndexType::TEXT4, IndexType::WIDE8},
-                             {"test/"});
+    db.snapshot().recursive_index_paths(task,
+                                        {IndexType::GRAM3, IndexType::HASH4,
+                                         IndexType::TEXT4, IndexType::WIDE8},
+                                        {"test/"});
     db.commit_task(task->id);
 
     make_query(db, "select \"nonexistent\";", {});


### PR DESCRIPTION
Sometimes we want to index files *without* a safety belt that index
provides. One of the reasons ot do this is when the list of files doesn't
fit into RAM (or storing it there is too memory expensive to be useful).

In this case, curated list of files can be provided to the db, and `nocheck`
modifier tells the db that the file list is guaranteed to be unique.