### PR TITLE
Optimise the FlatIndexBuilder save process.

### DIFF
--- a/libursa/FlatIndexBuilder.cpp
+++ b/libursa/FlatIndexBuilder.cpp
@@ -5,19 +5,73 @@
 
 #include "Utils.h"
 
-// raw_data will occupy at most 762 MB (MAX_TRIGRAMS*8/1024/1024)
+// raw_data will occupy at most 762 MB (MAX_TRIGRAMS*8 bytes)
 // TODO(): this should be parametrised by user somehow.
 constexpr int MAX_TRIGRAMS = 100000000;
 
 FlatIndexBuilder::FlatIndexBuilder(IndexType ntype)
-    : IndexBuilder(ntype), raw_data() {
+    : IndexBuilder(ntype), raw_data(), max_fileid_(0) {
     raw_data.reserve(MAX_TRIGRAMS);
 }
 
 void FlatIndexBuilder::add_trigram(FileId fid, TriGram val) {
-    // Consider packing the data in more memory efficient ways
-    // At least if it's worth it (TODO: measure performance).
     raw_data.push_back(fid | (uint64_t{val} << 40ULL));
+}
+
+// Countsort operating on bytes. Stable sort by (x) => (x>>shift) & 0xFF.
+void countsort(std::vector<uint64_t> *data_v, std::vector<uint64_t> *swap_v,
+               int shift) {
+    size_t count[256] = {};
+    size_t n = data_v->size();
+    uint64_t *data = data_v->data();
+    uint64_t *swap = swap_v->data();
+
+    if (data_v->size() != swap_v->size()) {
+        throw std::runtime_error("Swap space size doesn't match the data");
+    }
+
+    for (int64_t i = 0; i < n; i++) {
+        count[(data[i] >> shift) & 0xFF]++;
+    }
+
+    for (int64_t i = 1; i < 256; i++) {
+        count[i] += count[i - 1];
+    }
+
+    for (int64_t i = n - 1; i >= 0; i--) {
+        swap[count[(data[i] >> shift) & 0xFF] - 1] = data[i];
+        count[(data[i] >> shift) & 0xFF]--;
+    }
+
+    data_v->swap(*swap_v);
+}
+
+// Count number of bits in integer. Caveat: this will return 0 for 0.
+int count_bytes(uint32_t integer) {
+    int bytes = 0;
+    while (integer > 0) {
+        integer >>= 8;
+        bytes++;
+    }
+    return bytes;
+}
+
+// Radixsort, optimised for our data format. Core of the code is a standard
+// radix sort, with the following optimisations:
+// 1. We know that all records in data have a following format:
+// [TTT][FFFFF] maximum fileid won't be anyware close to 5 bytes, so we can
+//   skip sorting 4th, 5th, probably 6th and maybe even 7th byte.
+// 2. Counting sort needs a temporary storage space. Instead of doing a copy
+//   every time, use two vectors and swap their data.
+void flat_radixsort(std::vector<uint64_t> *data, uint64_t max_fileid) {
+    std::vector<uint64_t> swap(data->size());
+    int skip_to = count_bytes(max_fileid) * 8;
+    for (int shift = 0; shift < 64; shift += 8) {
+        if (shift >= skip_to && shift < 40) {
+            continue;
+        }
+        countsort(data, &swap, shift);
+    }
 }
 
 void FlatIndexBuilder::save(const std::string &fname) {
@@ -38,10 +92,10 @@ void FlatIndexBuilder::save(const std::string &fname) {
     auto offset = (uint64_t)out.tellp();
     std::vector<uint64_t> offsets(NUM_TRIGRAMS + 1);
     offsets[0] = offset;
-
     // Sort raw_data by trigrams (higher part of raw_data contains the
     // trigram value and lower part has the file ID).
-    std::sort(raw_data.begin(), raw_data.end());
+    // According to benchmarks, this is the slowest part of save() method.
+    flat_radixsort(&raw_data, max_fileid_);
 
     // Remove the duplicates (Files will often contain duplicated trigrams).
     raw_data.erase(std::unique(raw_data.begin(), raw_data.end()),
@@ -50,6 +104,7 @@ void FlatIndexBuilder::save(const std::string &fname) {
     TriGram last_trigram = 0;
     int64_t prev = -1;
 
+    std::vector<uint8_t> out_bytes;
     for (uint64_t d : raw_data) {
         TriGram val = (d >> 40ULL) & 0xFFFFFFU;
         FileId next = d & 0xFFFFFFFFFFULL;
@@ -67,14 +122,16 @@ void FlatIndexBuilder::save(const std::string &fname) {
         int64_t diff = (next - prev) - 1;
         while (diff >= 0x80U) {
             offset++;
-            out.put((uint8_t)(0x80U | (diff & 0x7FU)));
+            out_bytes.push_back((uint8_t)(0x80U | (diff & 0x7FU)));
             diff >>= 7;
         }
 
         offset++;
-        out.put((uint8_t)diff);
+        out_bytes.push_back((uint8_t)diff);
         prev = next;
     }
+
+    out.write((char *)out_bytes.data(), out_bytes.size());
 
     for (TriGram v = last_trigram + 1; v <= NUM_TRIGRAMS; v++) {
         offsets[v] = offset;
@@ -84,6 +141,7 @@ void FlatIndexBuilder::save(const std::string &fname) {
 }
 
 void FlatIndexBuilder::add_file(FileId fid, const uint8_t *data, size_t size) {
+    max_fileid_ = std::max(fid, max_fileid_);
     TrigramGenerator generator = get_generator_for(index_type());
     generator(data, size, [&](TriGram val) { add_trigram(fid, val); });
 }

--- a/libursa/FlatIndexBuilder.h
+++ b/libursa/FlatIndexBuilder.h
@@ -11,6 +11,7 @@ class FlatIndexBuilder : public IndexBuilder {
     // Contains uint64_t values in the following format:
     // [trigram: 24 bits] [file_id: 40 bits]
     std::vector<uint64_t> raw_data;
+    FileId max_fileid_;
 
     void add_trigram(FileId fid, TriGram val);
 


### PR DESCRIPTION
Saving the index builder is the slowest part of the whole process.
This change makes it much faster.

The slowest part of the save was std::sort on the ngrams. In this change I
rewrite the std::sort to a handwritten radixsort. This accounts for most
of the speedup.

Before (in ms):
1 - 2: 9611
1 - 2: 10055
1 - 2: 9555

After (in ms):
1 - 2: 1871
1 - 2: 1907
1 - 2: 1731

Another thing that was optimised is the process of saving data to disk. It
used to use ofstream::put, I've rewritten it to use a temporary std vector
and only spill the data at the end.

Before (in ms):
3 - 4: 1158
3 - 4: 1136
3 - 4: 1056

After (in ms):
3 - 4: 472
3 - 4: 520
3 - 4: 487

In total, this improves the index dump time significantly:

Before (in ms):
index(100, 1000000): 11797
index(100, 1000000): 12222
index(100, 1000000): 11612

After (in ms):
index(100, 1000000): 3285
index(100, 1000000): 3510
index(100, 1000000): 3166

This does not exhaust all the ways to optimise the indexes - for example,
vectorising the radixsort may make it even faster (though it sounds tricky).