### PR TITLE
Add a way to migrate database storage versions

### DIFF
--- a/libursa/CMakeLists.txt
+++ b/libursa/CMakeLists.txt
@@ -14,6 +14,8 @@ add_library(
     DatabaseName.h
     DatabaseSnapshot.cpp
     DatabaseSnapshot.h
+    DatabaseUpgrader.cpp
+    DatabaseUpgrader.h
     DatasetBuilder.cpp
     DatasetBuilder.h
     ExclusiveFile.cpp

--- a/libursa/DatabaseUpgrader.cpp
+++ b/libursa/DatabaseUpgrader.cpp
@@ -1,0 +1,64 @@
+#include "DatabaseUpgrader.h"
+
+#include <fstream>
+
+#include "Json.h"
+#include "Utils.h"
+#include "spdlog/spdlog.h"
+
+std::string extract_version(const json &dbjson) {
+    return dbjson.value("version", "1.0.0");
+}
+
+json read_json(std::string_view path) {
+    std::ifstream db_file(std::string(path), std::ifstream::binary);
+
+    if (db_file.fail()) {
+        throw std::runtime_error("Failed to open database file");
+    }
+
+    json db_json;
+
+    try {
+        db_file >> db_json;
+    } catch (json::parse_error &e) {
+        throw std::runtime_error("Failed to parse JSON");
+    }
+    return db_json;
+}
+
+void save_json(std::string_view path, const json &dbjson) {
+    std::string tmp_db_name = "tmp-" + random_hex_string(8);
+    std::ofstream db_file;
+    db_file.exceptions(std::ofstream::badbit);
+    db_file.open(tmp_db_name, std::ofstream::binary);
+    db_file << std::setw(4) << dbjson << std::endl;
+    db_file.flush();
+    db_file.close();
+    fs::rename(tmp_db_name, path);
+}
+
+void upgrade_v1_0_0(json *dbjson) { (*dbjson)["version"] = "1.3.2"; }
+
+void migrate_version(std::string_view path) {
+    std::string most_recent = "1.3.2";
+    std::string prev_version = "";
+    while (true) {
+        json db_json = std::move(read_json(path));
+        std::string version = extract_version(db_json);
+        if (version == prev_version) {
+            spdlog::error("Upgrade procedure failed. Trying to proceed...");
+            break;
+        } else if (version != prev_version && !prev_version.empty()) {
+            spdlog::info("Upgraded storage {} -> {}.", prev_version, version);
+        }
+        if (version == most_recent) {
+            break;
+        }
+        if (version == "1.0.0") {
+            upgrade_v1_0_0(&db_json);
+        }
+        prev_version = version;
+        save_json(path, db_json);
+    }
+}

--- a/libursa/DatabaseUpgrader.h
+++ b/libursa/DatabaseUpgrader.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <string_view>
+
+// Historically, ursadb database files were very stable. But we don't want
+// and don't have to guarantee their exact structure - especially since
+// they're JSON and can be easily extended with new data. This function will
+// read the db files from disk, upgrade them if necessary, and return.
+void migrate_version(std::string_view path);

--- a/src/Daemon.cpp
+++ b/src/Daemon.cpp
@@ -15,6 +15,7 @@
 #include "NetworkService.h"
 #include "libursa/Command.h"
 #include "libursa/Database.h"
+#include "libursa/DatabaseUpgrader.h"
 #include "libursa/DatasetBuilder.h"
 #include "libursa/FeatureFlags.h"
 #include "libursa/OnDiskDataset.h"
@@ -225,6 +226,8 @@ int main(int argc, char *argv[]) {
         printf("    %s database-file [bind-address]\n", argv[0]);
         return 1;
     }
+
+    migrate_version(argv[1]);
 
     try {
         Database db(argv[1]);


### PR DESCRIPTION
I'll quote my comment:

Historically, ursadb database files were very stable. But we don't want
and don't have to guarantee their exact structure - especially since
they're JSON and can be easily extended with new data. This function will
read the db files from disk, upgrade them if necessary, and return.