### PR TITLE
Rework compacting. Respect RAM more.

### DIFF
--- a/libursa/DatabaseSnapshot.cpp
+++ b/libursa/DatabaseSnapshot.cpp
@@ -228,25 +228,89 @@ void DatabaseSnapshot::execute(const Query &query,
     }
 }
 
-void DatabaseSnapshot::smart_compact(Task *task) const {
-    for (auto set : OnDiskDataset::get_taint_compatible_datasets(datasets)) {
-        std::vector<const OnDiskDataset *> candidates =
-            OnDiskDataset::get_compact_candidates(set);
+// For every dataset that we want to merge, we need to keep 8*(2**24) bytes
+// in memory (about 128MB). On the one hand, merging more datasets at once
+// is faster so we want to make this number big, OTOH on most computers RAM
+// is not unlimited so we need to make sure we won't crash the DB.
+// This should be parametrised by the DB - right now just hardcode it to 100.
+constexpr int MAX_DATASETS_TO_MERGE = 100;
 
-        if (!candidates.empty()) {
-            internal_compact(task, candidates);
-        }
-    }
+void DatabaseSnapshot::smart_compact(Task *task) const {
+    spdlog::info("Smart compact operation initiated");
+    try_compact(task, /*smart=*/true);
 }
 
 void DatabaseSnapshot::compact(Task *task) const {
-    for (auto set : OnDiskDataset::get_taint_compatible_datasets(datasets)) {
-        if (set.size() >= 2) {
-            internal_compact(task, set);
+    spdlog::info("Full compact operation initiated");
+    try_compact(task, /*smart=*/false);
+}
+
+void DatabaseSnapshot::try_compact(Task *task, bool smart) const {
+    // Try to find a best compact candidate. As a rating function, we use
+    // "number of datasets" - "average number of files", because we want to
+    // maximise number of datasets being compacted and minimise number of
+    // files being compacted (we want to compact small datasets first).
+    std::vector<const OnDiskDataset *> best_compact;
+    int64_t best_compact_value = std::numeric_limits<int64_t>::min();
+    for (auto &set : OnDiskDataset::get_compatible_datasets(datasets)) {
+        // Check every set of compatible datasets.
+        std::vector<const OnDiskDataset *> candidates;
+        if (smart) {
+            // When we're trying to be smart, ignore too small sets.
+            candidates = std::move(
+                OnDiskDataset::get_compact_candidates(std::move(set)));
+        } else {
+            candidates = std::move(set);
         }
+
+        // Ignore datasets that are locked.
+        std::vector<const OnDiskDataset *> ready_candidates;
+        for (const auto &candidate : candidates) {
+            if (!is_dataset_locked(candidate->get_name())) {
+                ready_candidates.push_back(candidate);
+            }
+        }
+
+        // It doesn't make sense to merge less than 2 datasets.
+        if (ready_candidates.size() < 2) {
+            continue;
+        }
+
+        // Try to merge small datasets first. Cull too big collections.
+        if (ready_candidates.size() > MAX_DATASETS_TO_MERGE) {
+            std::sort(ready_candidates.begin(), ready_candidates.end(),
+                      [](const auto &lhs, const auto &rhs) {
+                          return lhs->get_file_count() < rhs->get_file_count();
+                      });
+            ready_candidates.resize(MAX_DATASETS_TO_MERGE);
+        }
+
+        // Compute compact_value for this set, and maybe update best candidate.
+        uint64_t number_of_files = 0;
+        for (const auto &candidate : ready_candidates) {
+            number_of_files += candidate->get_file_count();
+        }
+        uint64_t avg_files = number_of_files / ready_candidates.size();
+        int64_t compact_value = ready_candidates.size() - avg_files;
+        if (compact_value > best_compact_value) {
+            best_compact_value = compact_value;
+            best_compact = std::move(ready_candidates);
+        }
+    }
+
+    // If we found a valid compact candidate, compact it.
+    if (best_compact.empty()) {
+        spdlog::info("No suitable compact candidate found.");
+    } else {
+        spdlog::info("Good candidate (cost: {}, datasets: {}).",
+                     best_compact_value, best_compact.size());
+        internal_compact(task, std::move(best_compact));
     }
 }
 
+// Do some plumbing necessary to pass the data to OnDiskDataset::merge.
+// After the merging, do more plumbing to add results to the task->changes
+// collection.
 void DatabaseSnapshot::internal_compact(
     Task *task, std::vector<const OnDiskDataset *> datasets) const {
     std::vector<std::string> ds_names;

--- a/libursa/DatabaseSnapshot.h
+++ b/libursa/DatabaseSnapshot.h
@@ -35,6 +35,13 @@ class DatabaseSnapshot {
 
     friend class Indexer;
 
+    void internal_compact(Task *task,
+                          std::vector<const OnDiskDataset *> datasets) const;
+
+    // Try to find a set of datasets that could use compacting, and compact
+    // them. If smart is true, won't index if the benefit is too small.
+    void try_compact(Task *task, bool smart) const;
+
    public:
     DatabaseName allocate_name(const std::string &type = "set") const;
 
@@ -90,10 +97,15 @@ class DatabaseSnapshot {
                          const std::string &dataset_name) const;
     void execute(const Query &query, const std::set<std::string> &taints,
                  Task *task, ResultWriter *out) const;
-    void smart_compact(Task *task) const;
+
+    // Compact the database. If there are at least two datasets that can be
+    // merged, it's guaranteed that they will be. This function still tries
+    // to find best candidates to merge.
     void compact(Task *task) const;
-    void internal_compact(Task *task,
-                          std::vector<const OnDiskDataset *> datasets) const;
+
+    // Compact the database, but in a "smart" way - if the algorithm decides
+    // that there are no good candidates, it won't do anything.
+    void smart_compact(Task *task) const;
     const OnDiskDataset *find_dataset(const std::string &name) const;
     const std::vector<const OnDiskDataset *> &get_datasets() const {
         return datasets;

--- a/libursa/OnDiskDataset.h
+++ b/libursa/OnDiskDataset.h
@@ -55,9 +55,12 @@ class OnDiskDataset {
     const std::set<std::string> &get_taints() const { return taints; }
     static std::vector<const OnDiskDataset *> get_compact_candidates(
         const std::vector<const OnDiskDataset *> &datasets);
+
+    // Returns vectors of compatible datasets. Datasets are called compatible
+    // when they can be merged with each other - they have the same types and
+    // the same taints.
     static std::vector<std::vector<const OnDiskDataset *>>
-    get_taint_compatible_datasets(
-        const std::vector<const OnDiskDataset *> &datasets);
+    get_compatible_datasets(const std::vector<const OnDiskDataset *> &datasets);
 };
 
 std::vector<FileId> internal_pick_common(


### PR DESCRIPTION
Right now we don't care how many datasets we want to compact at once.
Ursadb believes it can handle it. Ursadb believes in itself very hard,
it doesn't change the fact that with few hundred datasets at once
compacting gets pretty hard.

This change ensures that the database won't try to compact more than
a hardcoded number of datasets, and also it won't try to compact
more than one set of datasets (heh) at once. Finally, it tries to check
for the possibility that datasets are locked, and ignore them in this
case.