### PR TITLE
Add epsilon nodes to querygraphs and use them

### DIFF
--- a/libursa/QString.h
+++ b/libursa/QString.h
@@ -26,7 +26,7 @@ class QToken {
 
     QToken(const QToken &other) = default;
     QToken(std::vector<uint8_t> &&opts, uint8_t val, QTokenType type)
-        : opts_(std::move(opts)), legacy_type_(type), legacy_val_(val) {}
+        : legacy_type_(type), legacy_val_(val), opts_(std::move(opts)) {}
 
    public:
     QToken(QToken &&other) = default;

--- a/libursa/QueryResult.h
+++ b/libursa/QueryResult.h
@@ -10,7 +10,7 @@ class QueryResult {
     bool has_everything;
 
     QueryResult() : has_everything(true) {}
-    QueryResult(const QueryResult &other) = delete;
+    QueryResult(const QueryResult &other) = default;
 
    public:
     QueryResult(QueryResult &&other) = default;
@@ -31,4 +31,7 @@ class QueryResult {
     bool is_everything() const { return has_everything; }
 
     const std::vector<FileId> &vector() const { return results; }
+
+    // For when you really need to clone the query result
+    QueryResult clone() const { return *this; }
 };


### PR DESCRIPTION
Right now this is only used to slightly refactor graph parsing code. But
don't be mistaken, soon this will allow for huge improvements, because
it opens a possibility of merging querygraphs (without quadratic node cost).

It manifests itself in an ever so slight optimisation that can be seen here:

```
select {?1 ?2 ?3 ?4 ?5 ?6};                      average    146.137 files: 513
select {61 62 63} & {?1 ?2 ?3 ?4 ?5 ?6};         average    141.116 files: 60
select {61 62 63 ?? ?? ?? ?1 ?2 ?3 ?4 ?5 ?6 ?8}; average     21.913 files: 13
select {?1 ?2 ?3 ?4 ?5 ?6} & {61 62 63};         average    139.955 files: 60
select {?1 ?2 ?3 ?4 ?5 ?6 ?? ?? ?? 61 62 63};    average    136.847 files: 13
```

The middle operation is visibly faster than the other ones (even though
they're all equivalent except the first one). That's because now the complex
second query gets trimmed down to small numbers quickly. In the future, we'll
discover more optimisatoin opportunities like this.