### PR TITLE
Add two config related commands - config get and set

### DIFF
--- a/libursa/CMakeLists.txt
+++ b/libursa/CMakeLists.txt
@@ -8,6 +8,8 @@ add_library(
     Core.h
     Database.cpp
     Database.h
+    DatabaseConfig.cpp
+    DatabaseConfig.h
     DatabaseHandle.cpp
     DatabaseHandle.h
     DatabaseName.cpp

--- a/libursa/Command.h
+++ b/libursa/Command.h
@@ -87,6 +87,25 @@ class CompactCommand {
     const CompactType get_type() const { return type; }
 };
 
+class ConfigGetCommand {
+    std::vector<std::string> keys_;
+
+   public:
+    ConfigGetCommand(const std::vector<std::string> keys) : keys_(keys) {}
+    const std::vector<std::string> &keys() const { return keys_; }
+};
+
+class ConfigSetCommand {
+    std::string key_;
+    uint64_t value_;
+
+   public:
+    ConfigSetCommand(const std::string &key, uint64_t value)
+        : key_(key), value_(value) {}
+    const std::string &key() const { return key_; }
+    const uint64_t &value() const { return value_; }
+};
+
 class StatusCommand {
    public:
     StatusCommand() {}
@@ -120,7 +139,7 @@ class TaintCommand {
     const std::string &get_taint() const { return taint; }
 };
 
-using Command =
-    std::variant<SelectCommand, IndexCommand, IndexFromCommand,
-                 IteratorPopCommand, ReindexCommand, CompactCommand,
-                 StatusCommand, TopologyCommand, PingCommand, TaintCommand>;
+using Command = std::variant<SelectCommand, IndexCommand, IndexFromCommand,
+                             IteratorPopCommand, ReindexCommand, CompactCommand,
+                             ConfigGetCommand, ConfigSetCommand, StatusCommand,
+                             TopologyCommand, PingCommand, TaintCommand>;

--- a/libursa/Command.h
+++ b/libursa/Command.h
@@ -91,7 +91,7 @@ class ConfigGetCommand {
     std::vector<std::string> keys_;
 
    public:
-    ConfigGetCommand(const std::vector<std::string> keys) : keys_(keys) {}
+    ConfigGetCommand(const std::vector<std::string> &keys) : keys_(keys) {}
     const std::vector<std::string> &keys() const { return keys_; }
 };
 

--- a/libursa/Database.cpp
+++ b/libursa/Database.cpp
@@ -56,6 +56,8 @@ void Database::load_from_disk() {
                           iterator.value());
         load_iterator(name);
     }
+
+    config = std::move(DatabaseConfig(db_json["config"]));
 }
 
 void Database::create(const std::string &fname) {
@@ -94,8 +96,6 @@ void Database::save() {
     db_file.open(db_base / tmp_db_name, std::ofstream::binary);
 
     json db_json;
-    db_json["config"] = std::unordered_map<std::string, std::string>();
-
     std::vector<std::string> dataset_names;
     for (const auto *ds : working_datasets) {
         dataset_names.push_back(ds->get_name());
@@ -108,6 +108,8 @@ void Database::save() {
     }
     db_json["iterators"] = iterators_json;
     db_json["version"] = std::string(ursadb_format_version);
+
+    db_json["config"] = config.get_raw();
 
     db_file << std::setw(4) << db_json << std::endl;
     db_file.flush();
@@ -227,6 +229,10 @@ void Database::commit_task(uint64_t task_id) {
             uint64_t new_bytes = std::atoi(param.substr(0, split_loc).c_str());
             uint64_t new_files = std::atoi(param.substr(split_loc + 1).c_str());
             update_iterator(itname, new_bytes, new_files);
+        } else if (change.type == DbChangeType::ConfigChange) {
+            std::string key = change.obj_name;
+            uint64_t value = std::atoi(change.parameter.c_str());
+            config.set(key, value);
         } else {
             throw std::runtime_error("unknown change type requested");
         }
@@ -250,5 +256,5 @@ DatabaseSnapshot Database::snapshot() {
         cds.push_back(d);
     }
 
-    return DatabaseSnapshot(db_name, db_base, iterators, cds, tasks);
+    return DatabaseSnapshot(db_name, db_base, config, iterators, cds, tasks);
 }

--- a/libursa/Database.cpp
+++ b/libursa/Database.cpp
@@ -57,7 +57,7 @@ void Database::load_from_disk() {
         load_iterator(name);
     }
 
-    config = std::move(DatabaseConfig(db_json["config"]));
+    config = DatabaseConfig(db_json["config"]);
 }
 
 void Database::create(const std::string &fname) {

--- a/libursa/Database.h
+++ b/libursa/Database.h
@@ -6,6 +6,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "DatabaseConfig.h"
 #include "DatabaseSnapshot.h"
 #include "OnDiskDataset.h"
 #include "OnDiskIterator.h"
@@ -17,6 +18,7 @@ class Database {
     std::map<std::string, OnDiskIterator> iterators;
     std::vector<OnDiskDataset *> working_datasets;
     std::vector<std::unique_ptr<OnDiskDataset>> loaded_datasets;
+    DatabaseConfig config;
 
     uint64_t last_task_id;
     std::unordered_map<uint64_t, std::unique_ptr<Task>> tasks;

--- a/libursa/DatabaseConfig.cpp
+++ b/libursa/DatabaseConfig.cpp
@@ -21,8 +21,7 @@ uint64_t DatabaseConfig::get(const ConfigKey &key) const {
     if (defvals_.count(key.key()) == 0) {
         throw std::runtime_error("Invalid config key (get)");
     }
-    const auto &it = config_.find(key.key());
-    if (it == config_.end()) {
+    if (const auto &it = config_.find(key.key()); it == config_.end()) {
         return defvals_.at(key.key());
     }
     return *it;
@@ -35,8 +34,8 @@ void DatabaseConfig::set(const ConfigKey &key, uint64_t value) {
     config_[key.key()] = value;
 }
 
-std::map<std::string, uint64_t> DatabaseConfig::get_all() const {
-    std::map<std::string, uint64_t> result;
+std::unordered_map<std::string, uint64_t> DatabaseConfig::get_all() const {
+    std::unordered_map<std::string, uint64_t> result;
     for (const auto &[k, v] : defvals_) {
         result.emplace(k, get(k));
     }

--- a/libursa/DatabaseConfig.cpp
+++ b/libursa/DatabaseConfig.cpp
@@ -21,10 +21,10 @@ uint64_t DatabaseConfig::get(const ConfigKey &key) const {
     if (defvals_.count(key.key()) == 0) {
         throw std::runtime_error("Invalid config key (get)");
     }
-    if (const auto &it = config_.find(key.key()); it == config_.end()) {
-        return defvals_.at(key.key());
+    if (const auto &it = config_.find(key.key()); it != config_.end()) {
+        return *it;
     }
-    return *it;
+    return defvals_.at(key.key());
 }
 
 void DatabaseConfig::set(const ConfigKey &key, uint64_t value) {

--- a/libursa/DatabaseConfig.h
+++ b/libursa/DatabaseConfig.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <map>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 
 #include "Json.h"
 
@@ -21,7 +21,7 @@ const ConfigKey query_max_ngram = ConfigKey("query_max_ngram");
 
 class DatabaseConfig {
     json config_;
-    std::map<std::string, uint64_t> defvals_;
+    std::unordered_map<std::string, uint64_t> defvals_;
 
    public:
     DatabaseConfig() : config_() {}

--- a/libursa/DatabaseConfig.h
+++ b/libursa/DatabaseConfig.h
@@ -29,6 +29,6 @@ class DatabaseConfig {
 
     uint64_t get(const ConfigKey &key) const;
     void set(const ConfigKey &key, uint64_t value);
-    std::map<std::string, uint64_t> get_all() const;
+    std::unordered_map<std::string, uint64_t> get_all() const;
     const json get_raw() const { return config_; }
 };

--- a/libursa/DatabaseConfig.h
+++ b/libursa/DatabaseConfig.h
@@ -24,7 +24,7 @@ class DatabaseConfig {
     std::unordered_map<std::string, uint64_t> defvals_;
 
    public:
-    DatabaseConfig() : config_() {}
+    DatabaseConfig() : config_(std::unordered_map<std::string, uint64_t>()) {}
     explicit DatabaseConfig(json config);
 
     uint64_t get(const ConfigKey &key) const;

--- a/libursa/DatabaseConfig.h
+++ b/libursa/DatabaseConfig.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <map>
+#include <string>
+#include <string_view>
+
+#include "Json.h"
+
+class ConfigKey {
+    const std::string key_;
+
+   public:
+    ConfigKey(std::string key) : key_(key) {}
+    const std::string &key() const { return key_; }
+};
+
+namespace config {
+const ConfigKey query_max_edge = ConfigKey("query_max_edge");
+const ConfigKey query_max_ngram = ConfigKey("query_max_ngram");
+}  // namespace config
+
+class DatabaseConfig {
+    json config_;
+    std::map<std::string, uint64_t> defvals_;
+
+   public:
+    DatabaseConfig() : config_() {}
+    explicit DatabaseConfig(json config);
+
+    uint64_t get(const ConfigKey &key) const;
+    void set(const ConfigKey &key, uint64_t value);
+    std::map<std::string, uint64_t> get_all() const;
+    const json get_raw() const { return config_; }
+};

--- a/libursa/DatabaseSnapshot.cpp
+++ b/libursa/DatabaseSnapshot.cpp
@@ -9,12 +9,13 @@
 #include "spdlog/spdlog.h"
 
 DatabaseSnapshot::DatabaseSnapshot(
-    fs::path db_name, fs::path db_base,
+    fs::path db_name, fs::path db_base, DatabaseConfig config,
     std::map<std::string, OnDiskIterator> iterators,
     std::vector<const OnDiskDataset *> datasets,
     const std::unordered_map<uint64_t, std::unique_ptr<Task>> &tasks)
     : db_name(db_name),
       db_base(db_base),
+      config(config),
       iterators(iterators),
       datasets(datasets),
       tasks() {

--- a/libursa/DatabaseSnapshot.h
+++ b/libursa/DatabaseSnapshot.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <vector>
 
+#include "DatabaseConfig.h"
 #include "DatabaseHandle.h"
 #include "DatabaseName.h"
 #include "OnDiskDataset.h"
@@ -20,6 +21,7 @@ class DatabaseSnapshot {
     fs::path db_name;
     fs::path db_base;
     std::map<std::string, OnDiskIterator> iterators;
+    DatabaseConfig config;
     std::vector<const OnDiskDataset *> datasets;
     std::set<std::string> locked_datasets;
     std::set<std::string> locked_iterators;
@@ -37,7 +39,7 @@ class DatabaseSnapshot {
     DatabaseName allocate_name(const std::string &type = "set") const;
 
     DatabaseSnapshot(
-        fs::path db_name, fs::path db_base,
+        fs::path db_name, fs::path db_base, DatabaseConfig config,
         std::map<std::string, OnDiskIterator> iterators,
         std::vector<const OnDiskDataset *> datasets,
         const std::unordered_map<uint64_t, std::unique_ptr<Task>> &tasks);
@@ -97,4 +99,6 @@ class DatabaseSnapshot {
         return datasets;
     };
     const std::map<uint64_t, Task> &get_tasks() const { return tasks; };
+
+    const DatabaseConfig &get_config() const { return config; }
 };

--- a/libursa/Responses.cpp
+++ b/libursa/Responses.cpp
@@ -89,7 +89,7 @@ Response Response::status(const std::vector<TaskEntry> &tasks) {
     return r;
 }
 
-Response Response::config(std::map<std::string, uint64_t> values) {
+Response Response::config(std::unordered_map<std::string, uint64_t> values) {
     Response r("config");
     r.content["result"]["keys"] = values;
     return r;

--- a/libursa/Responses.cpp
+++ b/libursa/Responses.cpp
@@ -89,4 +89,10 @@ Response Response::status(const std::vector<TaskEntry> &tasks) {
     return r;
 }
 
+Response Response::config(std::map<std::string, uint64_t> values) {
+    Response r("config");
+    r.content["result"]["keys"] = values;
+    return r;
+}
+
 std::string Response::to_string() const { return content.dump(); }

--- a/libursa/Responses.h
+++ b/libursa/Responses.h
@@ -2,6 +2,7 @@
 
 #include <set>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "Core.h"

--- a/libursa/Responses.h
+++ b/libursa/Responses.h
@@ -42,7 +42,7 @@ class Response {
                                          uint64_t iterator_position,
                                          uint64_t total_files);
     static Response ok();
-    static Response config(std::map<std::string, uint64_t> values);
+    static Response config(std::unordered_map<std::string, uint64_t> values);
     static Response ping(const std::string &connection_id);
     static Response error(const std::string &message, bool retry = false);
     static Response topology(const std::vector<DatasetEntry> &datasets);

--- a/libursa/Responses.h
+++ b/libursa/Responses.h
@@ -42,6 +42,7 @@ class Response {
                                          uint64_t iterator_position,
                                          uint64_t total_files);
     static Response ok();
+    static Response config(std::map<std::string, uint64_t> values);
     static Response ping(const std::string &connection_id);
     static Response error(const std::string &message, bool retry = false);
     static Response topology(const std::vector<DatasetEntry> &datasets);

--- a/libursa/Task.cpp
+++ b/libursa/Task.cpp
@@ -8,6 +8,8 @@ std::string db_change_to_string(DbChangeType change) {
             return "DROP";
         case DbChangeType::Reload:
             return "RELOAD";
+        case DbChangeType::ConfigChange:
+            return "CONFIG_CHANGE";
         case DbChangeType::ToggleTaint:
             return "TOGGLE_TAINT";
         case DbChangeType::NewIterator:

--- a/libursa/Task.h
+++ b/libursa/Task.h
@@ -9,7 +9,8 @@ enum class DbChangeType {
     Reload = 3,
     ToggleTaint = 4,
     NewIterator = 5,
-    UpdateIterator = 6
+    UpdateIterator = 6,
+    ConfigChange = 7,
 };
 
 std::string db_change_to_string(DbChangeType change);

--- a/src/Daemon.cpp
+++ b/src/Daemon.cpp
@@ -116,7 +116,7 @@ Response execute_command(const ConfigGetCommand &cmd, Task *task,
     if (cmd.keys().empty()) {
         return Response::config(snap->get_config().get_all());
     }
-    std::map<std::string, uint64_t> vals;
+    std::unordered_map<std::string, uint64_t> vals;
     for (const auto &key : cmd.keys()) {
         vals[key] = snap->get_config().get(ConfigKey(key));
     }

--- a/src/Daemon.cpp
+++ b/src/Daemon.cpp
@@ -7,6 +7,7 @@
 #include <queue>
 #include <sstream>
 #include <stack>
+#include <unordered_map>
 #include <utility>
 #include <variant>
 #include <vector>

--- a/src/Daemon.cpp
+++ b/src/Daemon.cpp
@@ -111,6 +111,25 @@ Response execute_command(const IndexCommand &cmd, Task *task,
     return Response::ok();
 }
 
+Response execute_command(const ConfigGetCommand &cmd, Task *task,
+                         const DatabaseSnapshot *snap) {
+    if (cmd.keys().empty()) {
+        return Response::config(snap->get_config().get_all());
+    }
+    std::map<std::string, uint64_t> vals;
+    for (const auto &key : cmd.keys()) {
+        vals[key] = snap->get_config().get(ConfigKey(key));
+    }
+    return Response::config(vals);
+}
+
+Response execute_command(const ConfigSetCommand &cmd, Task *task,
+                         const DatabaseSnapshot *snap) {
+    task->changes.emplace_back(DbChangeType::ConfigChange, cmd.key(),
+                               std::to_string(cmd.value()));
+    return Response::ok();
+}
+
 Response execute_command(const ReindexCommand &cmd, Task *task,
                          const DatabaseSnapshot *snap) {
     const std::string &dataset_name = cmd.get_dataset_name();

--- a/teste2e/test_config.py
+++ b/teste2e/test_config.py
@@ -1,0 +1,34 @@
+from util import UrsadbTestContext
+from util import ursadb  # noqa
+
+
+def test_config_get_default(ursadb: UrsadbTestContext):
+    ursadb.check_request(
+        'config get "query_max_ngram";', {"keys": {"query_max_ngram": 16}},
+    )
+
+
+def test_config_get_many(ursadb: UrsadbTestContext):
+    ursadb.check_request(
+        'config get "query_max_ngram" "query_max_edge";',
+        {"keys": {"query_max_ngram": 16, "query_max_edge": 1}},
+    )
+
+
+def test_config_get_all(ursadb: UrsadbTestContext):
+    response = ursadb.request("config get;")
+    assert "result" in response
+    assert "keys" in response["result"]
+
+
+def test_config_get_error(ursadb: UrsadbTestContext):
+    resp = ursadb.request('config get "invalid"')
+    assert "error" in resp
+
+
+def test_config_set(ursadb: UrsadbTestContext):
+    ursadb.check_request('config set "query_max_ngram" 1337;')
+
+    ursadb.check_request(
+        'config get "query_max_ngram";', {"keys": {"query_max_ngram": 1337}},
+    )


### PR DESCRIPTION
This adds two commands: `config get` and `config set`:

```
config get;  # gets complete config
config get "key";  # gets key "key";
config get "key1" "key2";  # gets keys "key1" and "key2"
```

```
config set "key" 123  # sets key value
```

Currently recognised keys are `query_max_edge` and `query_max_edge` - but
they're not actually supported (i.e. the value is ignored).