### PR TITLE
Save namecache files

### DIFF
--- a/libursa/DatasetBuilder.cpp
+++ b/libursa/DatasetBuilder.cpp
@@ -50,7 +50,8 @@ void DatasetBuilder::save(const fs::path &db_base, const std::string &fname) {
     of.flush();
 
     std::set<std::string> taints;
-    store_dataset(db_base, fname, index_names, fname_list, taints);
+    store_dataset(db_base, fname, index_names, fname_list, std::nullopt,
+                  taints);
 }
 
 void DatasetBuilder::force_registered(const std::string &filepath) {

--- a/libursa/OnDiskFileIndex.cpp
+++ b/libursa/OnDiskFileIndex.cpp
@@ -30,7 +30,9 @@ OnDiskFileIndex::OnDiskFileIndex(const fs::path &db_base,
       files_fname(files_fname),
       cache_fname(cache_fname),
       files_file(db_base / files_fname) {  // <- cool race condition here
-    if (!fs::exists(db_base / cache_fname)) {
+    if (fs::exists(db_base / cache_fname)) {
+        file_count = fs::file_size(db_base / cache_fname) / 8 - 1;
+    } else {
         generate_namecache_file();
     }
     cache_file.emplace(db_base / cache_fname);

--- a/libursa/OnDiskFileIndex.cpp
+++ b/libursa/OnDiskFileIndex.cpp
@@ -2,7 +2,11 @@
 
 #include <fstream>
 
+#include "spdlog/spdlog.h"
+
 void OnDiskFileIndex::generate_namecache_file() {
+    spdlog::info("Namecache {} not found, generating", cache_fname);
+
     std::ofstream of;
     of.exceptions(std::ofstream::badbit);
     of.open(db_base / cache_fname, std::ofstream::binary);
@@ -20,13 +24,15 @@ void OnDiskFileIndex::generate_namecache_file() {
 }
 
 OnDiskFileIndex::OnDiskFileIndex(const fs::path &db_base,
-                                 const std::string &files_fname)
+                                 const std::string &files_fname,
+                                 const std::string &cache_fname)
     : db_base(db_base),
       files_fname(files_fname),
-      cache_fname("namecache." + files_fname),
+      cache_fname(cache_fname),
       files_file(db_base / files_fname) {  // <- cool race condition here
-
-    generate_namecache_file();
+    if (!fs::exists(db_base / cache_fname)) {
+        generate_namecache_file();
+    }
     cache_file.emplace(db_base / cache_fname);
 }
 
@@ -42,8 +48,6 @@ std::string OnDiskFileIndex::get_file_name(FileId fid) const {
     files_file.pread(filename.data(), filename_length, filename_start);
     return filename;
 }
-
-OnDiskFileIndex::~OnDiskFileIndex() { fs::remove(db_base / cache_fname); }
 
 void OnDiskFileIndex::for_each_filename(
     std::function<void(const std::string &)> cb) const {

--- a/libursa/OnDiskFileIndex.h
+++ b/libursa/OnDiskFileIndex.h
@@ -22,15 +22,16 @@ class OnDiskFileIndex {
     void generate_namecache_file();
 
    public:
-    OnDiskFileIndex(const fs::path &db_base, const std::string &files_fname);
+    OnDiskFileIndex(const fs::path &db_base, const std::string &files_fname,
+                    const std::string &cache_fname);
     OnDiskFileIndex(const OnDiskFileIndex &) = delete;
     OnDiskFileIndex(OnDiskFileIndex &&) = default;
-    ~OnDiskFileIndex();
 
     std::string get_file_name(FileId fid) const;
 
     const uint64_t get_file_count() const { return file_count; }
     const std::string &get_files_fname() const { return files_fname; }
+    const std::string &get_cache_fname() const { return cache_fname; }
 
     void for_each_filename(std::function<void(const std::string &)> cb) const;
 };

--- a/libursa/Utils.cpp
+++ b/libursa/Utils.cpp
@@ -292,6 +292,7 @@ std::vector<FileId> read_compressed_run(const uint8_t *start,
 void store_dataset(const fs::path &db_base, const std::string &fname,
                    const std::set<std::string> &index_names,
                    const std::string &fname_list,
+                   std::optional<std::string_view> fname_cache,
                    const std::set<std::string> &taints) {
     json dataset;
     json j_indices(index_names);
@@ -299,6 +300,10 @@ void store_dataset(const fs::path &db_base, const std::string &fname,
     dataset["indices"] = j_indices;
     dataset["files"] = fname_list;
     dataset["taints"] = taints;
+
+    if (fname_cache) {
+        dataset["filename_cache"] = std::string(*fname_cache);
+    }
 
     std::ofstream o;
     o.exceptions(std::ofstream::badbit);

--- a/libursa/Utils.h
+++ b/libursa/Utils.h
@@ -5,6 +5,7 @@
 #include <optional>
 #include <set>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "Core.h"
@@ -131,6 +132,7 @@ constexpr int get_b64_value(uint8_t character) {
 void store_dataset(const fs::path &db_base, const std::string &fname,
                    const std::set<std::string> &index_names,
                    const std::string &fname_list,
+                   std::optional<std::string_view> fname_cache,
                    const std::set<std::string> &taints);
 
 std::string bin_str_to_hex(const std::string &str);


### PR DESCRIPTION
Right now namecache files are regenerated every time. This slows down the startup unjustly. We should generate them, and update dataset with that file instead.

resolve #98