### PR TITLE
Another specialisation for select - select with datasets.

### DIFF
--- a/libursa/Command.h
+++ b/libursa/Command.h
@@ -11,17 +11,22 @@ static inline std::vector<IndexType> default_index_types() {
 }
 
 class SelectCommand {
-    Query query;
-    std::set<std::string> taints;
-    bool use_iterator;
+    Query query_;
+    std::set<std::string> taints_;
+    std::set<std::string> datasets_;
+    bool use_iterator_;
 
    public:
     SelectCommand(Query &&query, std::set<std::string> taints,
-                  bool use_iterator)
-        : query(std::move(query)), taints(taints), use_iterator(use_iterator) {}
-    const Query &get_query() const { return query; }
-    const std::set<std::string> &get_taints() const { return taints; }
-    const bool iterator_requested() const { return use_iterator; }
+                  std::set<std::string> datasets, bool use_iterator)
+        : query_(std::move(query)),
+          taints_(std::move(taints)),
+          datasets_(std::move(datasets)),
+          use_iterator_(use_iterator) {}
+    const Query &get_query() const { return query_; }
+    const std::set<std::string> &taints() const { return taints_; }
+    const std::set<std::string> &datasets() const { return datasets_; }
+    const bool iterator_requested() const { return use_iterator_; }
 };
 
 class IndexCommand {

--- a/src/Daemon.cpp
+++ b/src/Daemon.cpp
@@ -28,15 +28,44 @@
 #include "libursa/Utils.h"
 #include "spdlog/spdlog.h"
 
+void execute_select_internal(const SelectCommand &cmd, Task *task,
+                             const DatabaseSnapshot *snap, ResultWriter *out) {
+    // Query all datasets by default, unless user requested otherwise.
+    std::vector<const OnDiskDataset *> datasets_to_query;
+    datasets_to_query.reserve(cmd.datasets().size());
+    if (cmd.datasets().empty()) {
+        // No datasets selected explicitly == query everything.
+        datasets_to_query = std::move(snap->get_datasets());
+    } else {
+        for (const auto &dsname : cmd.datasets()) {
+            const auto *dsptr = snap->find_dataset(dsname);
+            if (dsptr == nullptr) {
+                throw std::runtime_error("Invalid specified in query");
+            }
+            datasets_to_query.push_back(dsptr);
+        }
+    }
+
+    const Query &query = cmd.get_query();
+    task->spec().estimate_work(datasets_to_query.size());
+
+    for (const auto *ds : datasets_to_query) {
+        task->spec().add_progress(1);
+        if (!ds->has_all_taints(cmd.taints())) {
+            continue;
+        }
+        ds->execute(query, out);
+    }
+}
+
 Response execute_command(const SelectCommand &cmd, Task *task,
                          const DatabaseSnapshot *snap) {
-    std::stringstream ss;
-    const Query &query = cmd.get_query();
-
     if (cmd.iterator_requested()) {
         DatabaseName data_filename = snap->allocate_name("iterator");
         FileResultWriter writer(data_filename.get_full_path());
-        snap->execute(query, cmd.get_taints(), task, &writer);
+
+        execute_select_internal(cmd, task, snap, &writer);
+
         // TODO DbChange should use DatabaseName type instead.
         DatabaseName meta_filename =
             snap->derive_name(data_filename, "itermeta");
@@ -48,7 +77,7 @@ Response execute_command(const SelectCommand &cmd, Task *task,
                                          writer.get_file_count());
     } else {
         InMemoryResultWriter writer;
-        snap->execute(query, cmd.get_taints(), task, &writer);
+        execute_select_internal(cmd, task, snap, &writer);
         return Response::select(writer.get());
     }
 }

--- a/src/Tests.cpp
+++ b/src/Tests.cpp
@@ -202,7 +202,21 @@ TEST_CASE("select literal into iterator", "[queryparser]") {
 TEST_CASE("select literal with taints", "[queryparser]") {
     auto cmd = parse<SelectCommand>("select with taints [\"hmm\"] \"MSM\";");
     REQUIRE(cmd.get_query() == q(std::move(mqs("MSM"))));
-    REQUIRE(cmd.get_taints() == std::set<std::string>{"hmm"});
+    REQUIRE(cmd.taints() == std::set<std::string>{"hmm"});
+}
+
+TEST_CASE("select literal with datasets", "[queryparser]") {
+    auto cmd = parse<SelectCommand>("select with datasets [\"hmm\"] \"MSM\";");
+    REQUIRE(cmd.get_query() == q(std::move(mqs("MSM"))));
+    REQUIRE(cmd.datasets() == std::set<std::string>{"hmm"});
+}
+
+TEST_CASE("select literal with datasets and taints", "[queryparser]") {
+    auto cmd = parse<SelectCommand>(
+        "select with taints [\"kot\"] with datasets [\"hmm\"] \"MSM\";");
+    REQUIRE(cmd.get_query() == q(std::move(mqs("MSM"))));
+    REQUIRE(cmd.datasets() == std::set<std::string>{"hmm"});
+    REQUIRE(cmd.taints() == std::set<std::string>{"kot"});
 }
 
 TEST_CASE("compact all command", "[queryparser]") {

--- a/teste2e/test_core.py
+++ b/teste2e/test_core.py
@@ -168,3 +168,38 @@ def test_compatible_merge(ursadb: UrsadbTestContext):
     check_query(ursadb, '"3marg"', ["3marg"])
 
     assert get_index_hash(ursadb, "gram3")[:16] == "7f6499ef40129703"
+
+
+def test_select_with_taints(ursadb: UrsadbTestContext):
+    store_files(
+        ursadb, "gram3", {"tainted": b"test",},
+    )
+
+    topology = ursadb.check_request("topology;")
+    dsname = list(topology["result"]["datasets"].keys())[0]
+
+    store_files(
+        ursadb, "gram3", {"untainted": b"test",},
+    )
+
+    ursadb.check_request(f'dataset "{dsname}" taint "test";')
+
+    check_query(ursadb, 'with taints [] "test"', ["tainted", "untainted"])
+    check_query(ursadb, 'with taints ["test"] "test"', ["tainted"])
+    check_query(ursadb, 'with taints ["other"] "test"', [])
+    check_query(ursadb, 'with taints ["test", "other"] "test"', [])
+
+
+def test_select_with_datasets(ursadb: UrsadbTestContext):
+    store_files(
+        ursadb, "gram3", {"first": b"test",},
+    )
+
+    topology = ursadb.check_request("topology;")
+    dsname = list(topology["result"]["datasets"].keys())[0]
+
+    store_files(
+        ursadb, "gram3", {"second": b"test",},
+    )
+
+    check_query(ursadb, f'with datasets ["{dsname}"] "test"', ["first"])

--- a/teste2e/test_stability_merge.py
+++ b/teste2e/test_stability_merge.py
@@ -66,7 +66,7 @@ def test_merge_ratchet(ursadb: UrsadbTestContext) -> None:
         socks.append(ursadb.start_request("compact all;"))
     for sock in socks:
         sock.recv_string()
-    
+
     files = ursadb.check_request("select {};")["result"]["files"]
     assert len(files) == 10
     ds = ursadb.check_request("topology;")["result"]["datasets"]


### PR DESCRIPTION
Ok, why would anyone need this. This is intended to decrease speed to first
result in mquery. Instead of doing one big query, mquery will query datasets
one by one.

Now I can hear you asking: WHY would the logic for this be in mquery? Isn't
async querying a pretty generic use-case? So I agree, but implementing this
in mquery opens a can of worms that I'm not ready to handle, for example:

- Database can change during the query (solution: persistent snapshots?)
- Database can't know when it's OK to stop streaming (for example, user
  cancelled a query, or yara can't catch up).
- It makes database performance even more opaque - is it idle? Or are there
  tasks busy in the background?

Because of this, I think that querying DSets one by one is a good solution for
now. The proper solution would be something like persistent snapshots +
continuable iterators... But yeah, why use a cannon when small PR like this
will do the trick.

Bonus points: we can run queries in parallel!