### PR TITLE
Make query graphs production ready

### DIFF
--- a/.github/workflows/test_experiments.yml
+++ b/.github/workflows/test_experiments.yml
@@ -38,4 +38,4 @@ jobs:
     - name: build
       run: cd build && make ursadb ursadb_new
     - name: test
-      run: python3 -m pytest
+      run: env EXPERIMENTAL_QUERY_GRAPHS=On python3 -m pytest

--- a/libursa/QString.h
+++ b/libursa/QString.h
@@ -53,6 +53,9 @@ class QToken {
     // Equivalent to `possible_values.size()`.
     uint64_t num_possible_values() const;
 
+    // Returns true, if the QToken is empty (doesn't accept any character).
+    bool empty() const { return opts_.empty(); }
+
     // Compares two QTokens. Assumes that `opts_` is in the ascending order.
     bool operator==(const QToken &a) const;
 

--- a/libursa/QueryGraph.h
+++ b/libursa/QueryGraph.h
@@ -30,7 +30,7 @@ class NodeId {
 using Edge = std::pair<NodeId, NodeId>;
 
 // Signature of the function used to query index by ngram.
-using QueryFunc = std::function<QueryResult(uint32_t)>;
+using QueryFunc = std::function<QueryResult(uint64_t)>;
 
 class QueryGraphNode {
     // Adjacency list for this node. Elements are indices in the parent
@@ -38,8 +38,8 @@ class QueryGraphNode {
     std::vector<NodeId> edges_;
 
     // N-gram with implicit n. For example, 0x112233 represents {11 22 33}.
-    // For obvious reasons, can't handle n-grams with n bigger than 4.
-    uint32_t gram_;
+    // For obvious reasons, can't handle n-grams with n bigger than 8.
+    uint64_t gram_;
 
     // Is this a special epsilon node. Epsilon nodes are no-ops that accept
     // every file. They are sometimes added during graph operations.
@@ -50,7 +50,7 @@ class QueryGraphNode {
 
    public:
     // Constructs a new graph node with assigned ngram value.
-    explicit QueryGraphNode(uint32_t gram) : gram_(gram), is_epsilon_(false) {}
+    explicit QueryGraphNode(uint64_t gram) : gram_(gram), is_epsilon_(false) {}
 
     // Adds edge from this node to another one.
     void add_edge(NodeId to) { edges_.push_back(to); }
@@ -59,7 +59,7 @@ class QueryGraphNode {
     bool is_epsilon() const { return is_epsilon_; }
 
     // Returns ngram assigned to this node, undefined if the node is epsilon.
-    uint32_t gram() const {
+    uint64_t gram() const {
         assert(!is_epsilon_);
         return gram_;
     }
@@ -109,10 +109,10 @@ class QueryGraph {
 
     // Merges ngrams of two given nodes assuming they're adjacent in query.
     // For example, will merge ABC and BCD into ABCD.
-    uint32_t combine(NodeId source, NodeId target) const;
+    uint64_t combine(NodeId source, NodeId target) const;
 
     // Adds a new node to the query graph, and returns its id.
-    NodeId make_node(uint32_t gram) {
+    NodeId make_node(uint64_t gram) {
         nodes_.emplace_back(QueryGraphNode(gram));
         return NodeId(nodes_.size() - 1);
     }

--- a/libursa/Utils.h
+++ b/libursa/Utils.h
@@ -12,8 +12,13 @@
 #include "QString.h"
 
 using TrigramCallback = std::function<void(TriGram)>;
+
+// Trigram generator - will call callback for every availbale trigram.
 using TrigramGenerator = void (*)(const uint8_t *mem, size_t size,
                                   TrigramCallback callback);
+
+// Validator for the token value. First parameter is offset, second token char.
+using TokenValidator = std::function<bool(uint32_t, uint8_t)>;
 
 // TODO get rid of this define
 namespace fs = std::experimental::filesystem;
@@ -21,7 +26,15 @@ namespace fs = std::experimental::filesystem;
 std::string_view get_version_string();
 std::string random_hex_string(unsigned long length);
 
+// Returns a function that can be used to generate ngrams of the specified type.
 TrigramGenerator get_generator_for(IndexType type);
+
+// Returns a TokenValidator for ngrams of the specified type.
+TokenValidator get_validator_for(IndexType type);
+
+// Returns a number of bytes needed for ngram of the specified type.
+size_t get_ngram_size_for(IndexType type);
+
 void gen_trigrams(const uint8_t *mem, size_t size, TrigramCallback callback);
 void gen_b64grams(const uint8_t *mem, size_t size, TrigramCallback callback);
 void gen_wide_b64grams(const uint8_t *mem, size_t size,
@@ -31,7 +44,8 @@ void gen_h4grams(const uint8_t *mem, size_t size, TrigramCallback callback);
 void combinations(const QString &qstr, size_t len, const TrigramGenerator &gen,
                   const TrigramCallback &cb);
 
-std::optional<TriGram> convert_gram(IndexType type, uint32_t source);
+// Converts ngram from raw representation to compressed 3byte id.
+std::optional<TriGram> convert_gram(IndexType type, uint64_t source);
 
 template <TrigramGenerator gen>
 std::vector<TriGram> get_trigrams_eager(const uint8_t *mem, size_t size) {

--- a/src/Tests.cpp
+++ b/src/Tests.cpp
@@ -1,6 +1,7 @@
 #define CATCH_CONFIG_MAIN
 
 #include <cstdlib>
+#include <string>
 #include <variant>
 
 #include "catch/Catch.h"
@@ -16,6 +17,9 @@
 #include "libursa/QueryParser.h"
 #include "libursa/ResultWriter.h"
 #include "libursa/Utils.h"
+
+// For string literal ( "xxx"s ).
+using namespace std::string_literals;
 
 TriGram gram3_pack(const char (&s)[4]) {
     TriGram v0 = (uint8_t)s[0];
@@ -691,7 +695,7 @@ TEST_CASE("Simple graph join", "[query_graphs]") {
 }
 
 QueryFunc make_oracle(std::string accepting) {
-    return [accepting](uint32_t gram1) {
+    return [accepting](uint64_t gram1) {
         if (accepting.find(static_cast<char>(gram1)) != std::string::npos) {
             return QueryResult::everything();
         }
@@ -712,4 +716,179 @@ TEST_CASE("Test wildcard query", "[query_graphs]") {
     REQUIRE(graph.run(make_oracle("cat")).is_everything());
     REQUIRE(graph.run(make_oracle("cet")).is_everything());
     REQUIRE(!graph.run(make_oracle("abc")).is_everything());
+}
+
+// Special value, ensure that all expected queries were asked.
+const uint64_t ORACLE_CHECK_MAGIC = std::numeric_limits<uint64_t>::max();
+
+QueryFunc make_expect_oracle(IndexType type, std::vector<std::string> strings) {
+    std::vector<uint32_t> accepted;
+    for (const auto &str : strings) {
+        const uint8_t *dataptr = reinterpret_cast<const uint8_t *>(str.data());
+        get_generator_for(type)(dataptr, str.size(), [&accepted](auto gram) {
+            accepted.push_back(gram);
+        });
+    }
+    return [type, accepted{std::move(accepted)},
+            strings{std::move(strings)}](uint64_t raw_gram) mutable {
+        if (raw_gram == ORACLE_CHECK_MAGIC) {
+            if (!accepted.empty()) {
+                throw std::runtime_error("Not all expected queries performed");
+            }
+            return QueryResult::everything();
+        }
+        std::optional<uint32_t> maybe_gram = convert_gram(type, raw_gram);
+        if (!maybe_gram) {
+            return QueryResult::everything();
+        }
+        uint32_t gram = *maybe_gram;
+        auto it = std::find(accepted.begin(), accepted.end(), gram);
+        if (it == accepted.end()) {
+            throw std::runtime_error("Unexpected query");
+        } else {
+            accepted.erase(it);
+        }
+        return QueryResult::everything();
+    };
+}
+
+// Internal function, used for tests.
+QueryGraph to_query_graph(const QString &str, int size, TokenValidator is_ok);
+
+// Ensure that the queries that were executed match exectly to expected ones.
+// This makes sure that query was parsed correctly and contains expected ngrams.
+// For example: ensure_queries(mqs("cats"), IndexType::GRAM3, {"cats"});
+// or: ensure_queries(mqs("cats"), IndexType::GRAM3, {"cat", "ats"});
+//
+// Make sure that there the graph will execute two queries, "cat" and "ats".
+void ensure_queries(const QString &query, IndexType type,
+                    std::vector<std::string> strings) {
+    auto validator = get_validator_for(type);
+    size_t size = get_ngram_size_for(type);
+    QueryGraph graph{to_query_graph(query, size, validator)};
+    auto oracle = make_expect_oracle(type, strings);
+    graph.run(oracle);
+    oracle(ORACLE_CHECK_MAGIC);
+}
+
+TEST_CASE("Test gram3 graph generator: gram3 x 0", "[query_graphs]") {
+    ensure_queries(mqs("ca"), IndexType::GRAM3, {});
+}
+
+TEST_CASE("Test gram3 graph generator: gram3 x 1", "[query_graphs]") {
+    ensure_queries(mqs("cat"), IndexType::GRAM3, {"cat"});
+}
+
+TEST_CASE("Test gram3 graph generator: gram3 x 2", "[query_graphs]") {
+    ensure_queries(mqs("cats"), IndexType::GRAM3, {"cats"});
+}
+
+TEST_CASE("Test text4 graph generator: text4 x 0", "[query_graphs]") {
+    ensure_queries(mqs("cat"), IndexType::TEXT4, {});
+}
+
+TEST_CASE("Test text4 graph generator: text4 x 1", "[query_graphs]") {
+    ensure_queries(mqs("cats"), IndexType::TEXT4, {"cats"});
+}
+
+TEST_CASE("Test text4 graph generator: text4 x 6", "[query_graphs]") {
+    ensure_queries(mqs("catsNdogs"), IndexType::TEXT4, {"catsNdogs"});
+}
+
+TEST_CASE("Test text4 graph generator: text4 x (2+2)", "[query_graphs]") {
+    ensure_queries(mqs("cats!dogs"), IndexType::TEXT4, {"cats", "dogs"});
+}
+
+TEST_CASE("Test hash4 graph generator: hash4 x 0", "[query_graphs]") {
+    ensure_queries(mqs("cat"), IndexType::HASH4, {});
+}
+
+TEST_CASE("Test hash4 graph generator: hash4 x (6)", "[query_graphs]") {
+    ensure_queries(mqs("cats!dogs"), IndexType::HASH4, {"cats!dogs"});
+}
+
+TEST_CASE("Test wide8 graph generator: wide8 x (0)", "[query_graphs]") {
+    ensure_queries(mqs("a\0b\0c\0d"s), IndexType::WIDE8, {});
+}
+
+TEST_CASE("Test wide8 graph generator: wide8 x (1)", "[query_graphs]") {
+    ensure_queries(mqs("a\0b\0c\0d\0"s), IndexType::WIDE8, {"a\0b\0c\0d\0"s});
+}
+
+TEST_CASE("Test wide8 graph generator: wide8 x (1)'", "[query_graphs]") {
+    ensure_queries(mqs("\0a\0b\0c\0d\0"s), IndexType::WIDE8, {"a\0b\0c\0d\0"s});
+}
+
+TEST_CASE("Test wide8 graph generator: wide8 x (2)''", "[query_graphs]") {
+    ensure_queries(mqs("cats\0a\0b\0c\0d\0hmm"s), IndexType::WIDE8,
+                   {"s\0a\0b\0c\0d\0"s});
+}
+
+TEST_CASE("Test wide8 graph generator: wide8 x (1+1)''", "[query_graphs]") {
+    ensure_queries(mqs("ssda\0b\0c\0d\0hmmq\0w\0e\0r\0xtq"s), IndexType::WIDE8,
+                   {"a\0b\0c\0d\0"s, "q\0w\0e\0r\0"s});
+}
+
+QString mqs_alphabet() {
+    QString expect;
+    expect.emplace_back(std::move(QToken::single('a')));
+    expect.emplace_back(std::move(QToken::single('b')));
+    expect.emplace_back(std::move(QToken::single('c')));
+    expect.emplace_back(std::move(QToken::with_values({'d', 'e', '!'})));
+    expect.emplace_back(std::move(QToken::single('f')));
+    expect.emplace_back(std::move(QToken::single('g')));
+    expect.emplace_back(std::move(QToken::single('h')));
+    return expect;
+}
+
+TEST_CASE("Test gram3 wildcards generator", "[query_graphs]") {
+    ensure_queries(mqs_alphabet(), IndexType::GRAM3,
+                   {"abc", "bcd", "cdf", "dfg", "bc!", "c!f", "!fg", "bce",
+                    "cef", "efg", "fgh"});
+}
+
+TEST_CASE("Test text4 wildcards generator", "[query_graphs]") {
+    ensure_queries(mqs_alphabet(), IndexType::TEXT4, {"abcdfgh", "abcefgh"});
+}
+
+TEST_CASE("Test hash4 wildcards generator", "[query_graphs]") {
+    ensure_queries(mqs_alphabet(), IndexType::HASH4,
+                   {"abcdfgh", "abcefgh", "abc!fgh"});
+}
+
+QString mqs_null_alphabet() {
+    QString expect;
+    expect.emplace_back(std::move(QToken::single('a')));
+    expect.emplace_back(std::move(QToken::single('\0')));
+    expect.emplace_back(std::move(QToken::single('b')));
+    expect.emplace_back(std::move(QToken::single('\0')));
+    expect.emplace_back(std::move(QToken::with_values({'c', 'd'})));
+    expect.emplace_back(std::move(QToken::with_values({'\0', 'e'})));
+    expect.emplace_back(std::move(QToken::single('d')));
+    expect.emplace_back(std::move(QToken::single('\0')));
+    return expect;
+}
+
+TEST_CASE("Test wide8 wildcards generator (alphabet)", "[query_graphs]") {
+    ensure_queries(mqs_alphabet(), IndexType::WIDE8,
+                   {"a\0b\0c\0d\0", "a\0b\0d\0d\0"});
+}
+
+QString mqs_spaghetti() {
+    QString expect;
+    expect.emplace_back(std::move(QToken::with_values({'a', '\0'})));
+    expect.emplace_back(std::move(QToken::with_values({'b', '\0'})));
+    expect.emplace_back(std::move(QToken::with_values({'c', '\0'})));
+    expect.emplace_back(std::move(QToken::with_values({'d', '\0'})));
+    expect.emplace_back(std::move(QToken::with_values({'e', '\0'})));
+    expect.emplace_back(std::move(QToken::with_values({'f', '\0'})));
+    expect.emplace_back(std::move(QToken::with_values({'g', '\0'})));
+    expect.emplace_back(std::move(QToken::with_values({'h', '\0'})));
+    expect.emplace_back(std::move(QToken::with_values({'i', '\0'})));
+    return expect;
+}
+
+TEST_CASE("Test wide8 wildcards generator (spaghetti)", "[query_graphs]") {
+    ensure_queries(mqs_alphabet(), IndexType::WIDE8,
+                   {"a\0c\0e\0g\0", "b\0d\0f\0i\0"});
 }

--- a/teste2e/test_format_upgrades.py
+++ b/teste2e/test_format_upgrades.py
@@ -2,7 +2,6 @@ from util import UrsadbTestContext
 from util import ursadb  # noqa
 import json
 import subprocess
-import time
 from pathlib import Path
 import tempfile
 import os

--- a/teste2e/test_iterators.py
+++ b/teste2e/test_iterators.py
@@ -10,7 +10,7 @@ def test_pop(ursadb: UrsadbTestContext) -> None:
     )
     response = ursadb.check_request(
         'select into iterator "file";',
-        {"mode": "iterator", "file_count": 3, "iterator": "#UNK#",},
+        {"mode": "iterator", "file_count": 3, "iterator": "#UNK#"},
     )
     iterator = response["result"]["iterator"]
 

--- a/teste2e/test_sanity.py
+++ b/teste2e/test_sanity.py
@@ -19,5 +19,5 @@ def test_topology(ursadb: UrsadbTestContext):
 
 def test_status(ursadb: UrsadbTestContext):
     ursadb.check_request(
-        "status;", {"tasks": [], "ursadb_version": "#UNK#",},
+        "status;", {"tasks": [], "ursadb_version": "#UNK#"},
     )

--- a/teste2e/test_stability_merge.py
+++ b/teste2e/test_stability_merge.py
@@ -1,12 +1,11 @@
 """Test stability of compacting in a highly multithreaded environment.
 
 Especially, ensure that merge don't lose files, and there can't be two merge
-operations at once. 
+operations at once.
 """
 
 from util import UrsadbTestContext, store_files
 from util import ursadb  # noqa
-import json
 from multiprocessing import Pool
 import zmq
 import time
@@ -56,9 +55,9 @@ def test_concurrent_merge(ursadb: UrsadbTestContext) -> None:
 
 
 def test_merge_ratchet(ursadb: UrsadbTestContext) -> None:
-    """ Test that no files are lost when we index and merge at the same time """
+    """Test that no files are lost when we index and merge at the same time"""
     socks = []
-    for i in range(10):
+    for i in range(6):
         store_files(
             ursadb, "gram3", {f"file{i}name": b"filedata" + str(i).encode()},
         )
@@ -66,8 +65,8 @@ def test_merge_ratchet(ursadb: UrsadbTestContext) -> None:
         socks.append(ursadb.start_request("compact all;"))
     for sock in socks:
         sock.recv_string()
-    
+
     files = ursadb.check_request("select {};")["result"]["files"]
-    assert len(files) == 10
+    assert len(files) == 6
     ds = ursadb.check_request("topology;")["result"]["datasets"]
-    assert len(ds) < 9  # ideally 5, but that would require too much timing
+    assert len(ds) < 5  # ideally 3, but that would require too much timing


### PR DESCRIPTION
- no arbitrary restriction on wide8 queries
- actually unit test them (regression found)
- make query graph expansion faster (validate grams before)

With this change they will be *basically* ready to deploy as a default
configuration. Maybe few more tests and I think we can :shipit:.