### PR TITLE
Add performance counters to the response.

### DIFF
--- a/libursa/DatabaseSnapshot.h
+++ b/libursa/DatabaseSnapshot.h
@@ -82,8 +82,10 @@ class DatabaseSnapshot {
 
     void reindex_dataset(Task *task, const std::vector<IndexType> &types,
                          const std::string &dataset_name) const;
-    void execute(const Query &query, const std::set<std::string> &taints,
-                 Task *task, ResultWriter *out) const;
+    QueryStatistics execute(const Query &query,
+                            const std::set<std::string> &taints,
+                            const std::set<std::string> &datasets, Task *task,
+                            ResultWriter *out) const;
 
     // Find candidates for compacting, but in a "smart" way - if the algorithm
     // decides that there are no good candidates, it won't do anything.

--- a/libursa/OnDiskDataset.h
+++ b/libursa/OnDiskDataset.h
@@ -40,7 +40,7 @@ class OnDiskDataset {
     }
     void toggle_taint(const std::string &taint_name);
     bool has_all_taints(const std::set<std::string> &taints) const;
-    void execute(const Query &query, ResultWriter *out) const;
+    QueryStatistics execute(const Query &query, ResultWriter *out) const;
     uint64_t get_file_count() const { return files_index->get_file_count(); }
     void for_each_filename(std::function<void(const std::string &)> cb) const {
         files_index->for_each_filename(cb);

--- a/libursa/QueryResult.cpp
+++ b/libursa/QueryResult.cpp
@@ -3,29 +3,60 @@
 #include <algorithm>
 
 void QueryResult::do_or(const QueryResult &other) {
+    QueryOperation op(file_count() + other.file_count());
     if (this->is_everything() || other.is_everything()) {
         has_everything = true;
-        return;
+        results.clear();
+    } else {
+        std::vector<FileId> new_results;
+        std::set_union(other.results.begin(), other.results.end(),
+                       results.begin(), results.end(),
+                       std::back_inserter(new_results));
+        std::swap(new_results, results);
     }
-
-    std::vector<FileId> new_results;
-    std::set_union(other.results.begin(), other.results.end(), results.begin(),
-                   results.end(), std::back_inserter(new_results));
-    std::swap(new_results, results);
+    stats_.add_or(op.end(file_count()));
+    stats_.add(other.stats_);
 }
 
 void QueryResult::do_and(const QueryResult &other) {
+    QueryOperation op(file_count() + other.file_count());
     if (other.is_everything()) {
-        return;
-    }
-    if (this->is_everything()) {
+    } else if (this->is_everything()) {
         results = other.results;
         has_everything = other.has_everything;
-        return;
+    } else {
+        auto new_end = std::set_intersection(
+            other.results.begin(), other.results.end(), results.begin(),
+            results.end(), results.begin());
+        results.erase(new_end, results.end());
     }
+    stats_.add_and(op.end(file_count()));
+    stats_.add(other.stats_);
+}
 
-    auto new_end =
-        std::set_intersection(other.results.begin(), other.results.end(),
-                              results.begin(), results.end(), results.begin());
-    results.erase(new_end, results.end());
+QueryCounter QueryOperation::end(uint32_t out_files) const {
+    auto duration = std::chrono::steady_clock::now() - start_;
+    return QueryCounter(1, in_files_, out_files, duration);
+}
+
+void QueryCounter::add(const QueryCounter &other) {
+    count_ += other.count_;
+    in_files_ += other.in_files_;
+    out_files_ += other.out_files_;
+    duration_ += other.duration_;
+}
+
+void QueryStatistics::add(const QueryStatistics &other) {
+    ors_.add(other.ors_);
+    ands_.add(other.ands_);
+    reads_.add(other.reads_);
+}
+
+std::unordered_map<std::string, QueryCounter> QueryStatistics::counters()
+    const {
+    std::unordered_map<std::string, QueryCounter> result;
+    result["or"] = ors_;
+    result["and"] = ands_;
+    result["read"] = reads_;
+    return result;
 }

--- a/libursa/QueryResult.h
+++ b/libursa/QueryResult.h
@@ -1,21 +1,102 @@
 #pragma once
 
+#include <chrono>
+#include <unordered_map>
 #include <vector>
 
 #include "Core.h"
+
+// Counter utility class, for measuring a single aspect of performance.
+class QueryCounter {
+    // How many times was the operation performed? For aggregated counters.
+    uint32_t count_;
+
+    // How many files did the operation touch?
+    uint64_t in_files_;
+
+    // How many files did the operation produce?
+    uint64_t out_files_;
+
+    // How long did the operation take?
+    std::chrono::steady_clock::duration duration_;
+
+   public:
+    QueryCounter() : count_{}, in_files_{}, out_files_{}, duration_{} {}
+
+    QueryCounter(uint32_t count, uint64_t in_files, uint64_t out_files,
+                 std::chrono::steady_clock::duration duration)
+        : count_(count),
+          in_files_(in_files),
+          out_files_(out_files),
+          duration_(duration) {}
+
+    uint32_t count() const { return count_; }
+    uint64_t in_files() const { return in_files_; }
+    uint64_t out_files() const { return out_files_; }
+    uint64_t duration_ms() const {
+        return std::chrono::duration_cast<std::chrono::milliseconds>(duration_)
+            .count();
+    }
+
+    void add(const QueryCounter &other);
+};
+
+class QueryOperation {
+    uint32_t in_files_;
+    std::chrono::steady_clock::time_point start_;
+
+   public:
+    QueryOperation(uint32_t in_files)
+        : in_files_{in_files}, start_{std::chrono::steady_clock::now()} {}
+
+    QueryCounter end(uint32_t out_files) const;
+};
+
+// Container for various query performance counters and statistics.
+class QueryStatistics {
+    // Counter for `and` operations.
+    QueryCounter ands_;
+
+    // Counter for `or` operations.
+    QueryCounter ors_;
+
+    // Counter for file reads.
+    QueryCounter reads_;
+
+   public:
+    QueryStatistics() : ands_{}, ors_{}, reads_{} {}
+    QueryStatistics(uint64_t file_count)
+        : ands_{}, ors_{}, reads_{1, 0, file_count, {}} {}
+
+    void add_and(QueryCounter counter) { ands_.add(counter); }
+
+    void add_or(QueryCounter counter) { ors_.add(counter); }
+
+    void add_read(QueryCounter counter) { reads_.add(counter); }
+
+    void add(const QueryStatistics &other);
+
+    // Create a map with all counters (for serialisation).
+    std::unordered_map<std::string, QueryCounter> counters() const;
+};
 
 class QueryResult {
    private:
     std::vector<FileId> results;
     bool has_everything;
+    QueryStatistics stats_;
 
-    QueryResult() : has_everything(true) {}
+    QueryResult() : results{}, has_everything{true}, stats_{} {}
     QueryResult(const QueryResult &other) = default;
+
+    // Number of explicitly stored files. This will return 0 for
+    // QueryResult::everything.
+    size_t file_count() const { return results.size(); }
 
    public:
     QueryResult(QueryResult &&other) = default;
     explicit QueryResult(std::vector<FileId> &&results)
-        : results(results), has_everything(false) {}
+        : results(results), has_everything(false), stats_{results.size()} {}
     QueryResult &operator=(QueryResult &&other) = default;
 
     static QueryResult empty() { return QueryResult(std::vector<FileId>()); }
@@ -31,6 +112,8 @@ class QueryResult {
     bool is_everything() const { return has_everything; }
 
     const std::vector<FileId> &vector() const { return results; }
+
+    const QueryStatistics stats() const { return stats_; }
 
     // For when you really need to clone the query result
     QueryResult clone() const { return *this; }

--- a/libursa/Responses.cpp
+++ b/libursa/Responses.cpp
@@ -2,10 +2,25 @@
 
 #include "Version.h"
 
-Response Response::select(const std::vector<std::string> &files) {
+void Response::write_counters(
+    const std::unordered_map<std::string, QueryCounter> &counters) {
+    for (const auto &[name, counter] : counters) {
+        content["counters"][name]["count"] = counter.count();
+        content["counters"][name]["in_files"] = counter.in_files();
+        content["counters"][name]["out_files"] = counter.out_files();
+        content["counters"][name]["milliseconds"] = counter.duration_ms();
+    }
+}
+
+Response Response::select(
+    const std::vector<std::string> &files,
+    const std::unordered_map<std::string, QueryCounter> &counters) {
     Response r("select");
     r.content["result"]["mode"] = "raw";
     r.content["result"]["files"] = files;
+
+    r.write_counters(counters);
+
     return r;
 }
 
@@ -20,12 +35,16 @@ Response Response::select_from_iterator(const std::vector<std::string> &files,
     return r;
 }
 
-Response Response::select_iterator(const std::string &iterator,
-                                   uint64_t file_count) {
+Response Response::select_iterator(
+    const std::string &iterator, uint64_t file_count,
+    const std::unordered_map<std::string, QueryCounter> &counters) {
     Response r("select");
     r.content["result"]["mode"] = "iterator";
     r.content["result"]["file_count"] = file_count;
     r.content["result"]["iterator"] = iterator;
+
+    r.write_counters(counters);
+
     return r;
 }
 

--- a/libursa/Responses.h
+++ b/libursa/Responses.h
@@ -7,6 +7,7 @@
 
 #include "Core.h"
 #include "Json.h"
+#include "QueryResult.h"
 #include "Task.h"
 
 struct IndexEntry {
@@ -27,10 +28,16 @@ class Response {
 
     Response(const std::string &type) { content["type"] = type; }
 
+    void write_counters(
+        const std::unordered_map<std::string, QueryCounter> &counters);
+
    public:
-    static Response select(const std::vector<std::string> &files);
-    static Response select_iterator(const std::string &filename,
-                                    uint64_t file_count);
+    static Response select(
+        const std::vector<std::string> &files,
+        const std::unordered_map<std::string, QueryCounter> &counters);
+    static Response select_iterator(
+        const std::string &filename, uint64_t file_count,
+        const std::unordered_map<std::string, QueryCounter> &counters);
     static Response select_from_iterator(const std::vector<std::string> &files,
                                          uint64_t iterator_position,
                                          uint64_t total_files);

--- a/src/Tests.cpp
+++ b/src/Tests.cpp
@@ -600,7 +600,7 @@ void make_query(Database &db, std::string query_str,
     Task task(task_spec);
     auto cmd = parse<SelectCommand>(query_str);
     InMemoryResultWriter out;
-    db.snapshot().execute(cmd.get_query(), {}, &task, &out);
+    db.snapshot().execute(cmd.get_query(), {}, {}, &task, &out);
     db.commit_task(*task_spec, task.changes());
 
     std::vector<std::string> out_fixed;


### PR DESCRIPTION
`select` queries will return some useful metrics (for example,
number of files read and written).

```
ursadb> select {a? b? c? d? ee ff};
{
    "counters": {
        "and": {
            "count": 419339,
            "in_files": 14714965,
            "milliseconds": 73,
            "out_files": 44160
        },
        "or": {
            "count": 419424,
            "in_files": 368944,
            "milliseconds": 17,
            "out_files": 367750
        },
        "read": {
            "count": 838758,
            "in_files": 0,
            "milliseconds": 0,
            "out_files": 14672000
        }
    },
    "result": {
        "files": [
            "/home/msm/Projects/mquery/samples/f4b3d12706927fc74767b1cfac194801"
        ],
        "mode": "raw"
    },
    "type": "select"
}
```

(milliseconds in the `read` section are of course not valid).