### PR TITLE
Don't do unnecessary ORs in query graph selects.

### DIFF
--- a/libursa/QueryGraph.cpp
+++ b/libursa/QueryGraph.cpp
@@ -138,6 +138,10 @@ QueryResult masked_or(std::vector<const QueryResult *> &&to_or,
         // Empty or list means everything(). The only case when it happens
         // is for sources, when it makes sense to just return mask.
         return std::move(mask);
+    } else if (to_or.size() == 1) {
+        // In a very common case of a single predecessor, just do explicit and.
+        mask.do_and(*to_or[0]);
+        return std::move(mask);
     }
     QueryResult result{QueryResult::empty()};
     for (const auto *query : to_or) {


### PR DESCRIPTION
When there is only single predecessor, do a simple AND without ANDing with a temporary and ORing with the empty result.

Before:
```
    "counters": {
        "and": {
            "count": 33,
            "in_files": 432,
            "milliseconds": 0,
            "out_files": 4
        },
        "or": {
            "count": 30,
            "in_files": 4,
            "milliseconds": 0,
            "out_files": 4
        },
        "read": {
            "count": 60,
            "in_files": 0,
            "milliseconds": 0,
            "out_files": 428
        }
    },
```

After:
```
    "counters": {
        "and": {
            "count": 33,
            "in_files": 432,
            "milliseconds": 0,
            "out_files": 4
        },
        "or": {
            "count": 8,
            "in_files": 0,
            "milliseconds": 0,
            "out_files": 0
        },
        "read": {
            "count": 38,
            "in_files": 0,
            "milliseconds": 0,
            "out_files": 428
        }
    },
```