### PR TITLE
Don't do unnecessary index reads for empty ANDs.

### DIFF
--- a/libursa/QueryResult.h
+++ b/libursa/QueryResult.h
@@ -107,9 +107,13 @@ class QueryResult {
 
     void do_and(const QueryResult &other);
 
-    // If true, means that QueryResults represents special
-    // "uninitialized" value, "set of all FileIds in DataSet".
+    // If true, means that QueryResults represents special "uninitialized"
+    // value, "set of all FileIds in DataSet".
     bool is_everything() const { return has_everything; }
+
+    // If true, means that QueryResults is empty. This is useful for short
+    // circuiting in some optimisations.
+    bool is_empty() const { return !has_everything && results.empty(); }
 
     const std::vector<FileId> &vector() const { return results; }
 


### PR DESCRIPTION
Before:

```
    "counters": {
        "and": {
            "count": 217,
            "in_files": 209,
            "milliseconds": 0,
            "out_files": 0
        },
        "or": {
            "count": 8,
            "in_files": 0,
            "milliseconds": 0,
            "out_files": 0
        },
        "read": {
            "count": 222,
            "in_files": 0,
            "milliseconds": 0,
            "out_files": 209
        }
    },
```

After:
```
    "counters": {
        "and": {
            "count": 11,
            "in_files": 0,
            "milliseconds": 0,
            "out_files": 0
        },
        "or": {
            "count": 0,
            "in_files": 0,
            "milliseconds": 0,
            "out_files": 0
        },
        "read": {
            "count": 8,
            "in_files": 0,
            "milliseconds": 0,
            "out_files": 0
        }
    },
```

Probably won't matter much on real-world queries and big indexes, though :thinking: 