### PR TITLE
Fix failed optimisation for OR on empty graphs.

### DIFF
--- a/libursa/QueryGraph.cpp
+++ b/libursa/QueryGraph.cpp
@@ -319,8 +319,8 @@ void QueryGraph::or_(QueryGraph &&other) {
     // 1. Special case for empty graph.
     if (nodes_.empty() || other.nodes_.empty()) {
         nodes_.clear();
-        NodeId everything = make_epsilon();
-        sources_.emplace_back(everything);
+        sources_.clear();
+        return;
     }
 
     // 2. Paste the second graph into this one, updating IDs along the way.


### PR DESCRIPTION
This could produce invalid results on some complex-but-useful queries, like:

select into iterator ((({(61|41) (62|42) (63|43) (64|44)} | {(61|41) 00 (62|42) 00 (63|43) 00 (64|44) 00})))

(in this case, even segfault because sources were not cleaned properly).