### PR TITLE
Add a memory lock feature

### DIFF
--- a/libursa/Database.h
+++ b/libursa/Database.h
@@ -28,7 +28,9 @@ class Database {
 
     explicit Database(const std::string &fname, bool initialize);
 
-    bool can_acquire(const DatabaseLock &newlock) const;
+    bool can_acquire(const DatasetLock &newlock) const;
+    bool can_acquire(const IteratorLock &newlock) const;
+    bool can_acquire(const MemoryLock &newlock) const;
 
    public:
     explicit Database(const std::string &fname);

--- a/libursa/DatabaseConfig.h
+++ b/libursa/DatabaseConfig.h
@@ -41,6 +41,17 @@ class ConfigKey {
         };
     }
 
+    // Maximum memory, in mebibytes, the database is allowed to use. Tasks will
+    // be rejected if it would cause the db to exceed this limit. This only
+    // includes big allocations, and doesn't take other processes in the system
+    // into account, so it shouldn't be set to physical RAM size of the system.
+    // Recommendation: Change the default. Estimate the absolute maximum the
+    // machine can handle. Ursa will never use more memory than minimum, so it
+    // only limits the number of tasks that will be processed in parallel.
+    const static ConfigKey database_max_memory() {
+        return ConfigKey("database_max_memory", 4294967296, 2048, 4294967296);
+    }
+
     // Maximum number of values a first or last character in sequence can take
     // to be considered when planning a query. The default is a conservative 1,
     // so query plam will never start or end with a wildcard.

--- a/libursa/DatabaseLock.h
+++ b/libursa/DatabaseLock.h
@@ -5,6 +5,8 @@
 #include <unordered_map>
 #include <variant>
 
+// Represents a lock of a single dataset. Dataset can be locked by only one
+// task at once.
 class DatasetLock {
     std::string dataset_;
 
@@ -14,6 +16,8 @@ class DatasetLock {
     const std::string &target() const { return dataset_; }
 };
 
+// Represents a lock of a single iterator. Iterator can be locked by only one
+// task at once.
 class IteratorLock {
     std::string iterator_;
 
@@ -23,6 +27,25 @@ class IteratorLock {
     const std::string &target() const { return iterator_; }
 };
 
-using DatabaseLock = std::variant<DatasetLock, IteratorLock>;
+// Represents a lock of N mebibytes (1 MiB = 2**20 bytes = a bit more than 1MB).
+// Tasks should lock enough memory to work in a worst case, though it's not
+// strictly checked (especially for queries with many wildcards).
+class MemoryLock {
+    uint64_t mebibytes_;
+    const std::string description_;
+
+   public:
+    MemoryLock(uint64_t mebibytes)
+        : mebibytes_(mebibytes),
+          description_(std::to_string(mebibytes) + "MiB") {}
+
+    // Amount of memory locked by this task
+    uint64_t mebibytes() const { return mebibytes_; }
+
+    // Used for human-friendly description of this lock.
+    const std::string &target() const { return description_; }
+};
+
+using DatabaseLock = std::variant<DatasetLock, IteratorLock, MemoryLock>;
 
 std::string describe_lock(const DatabaseLock &lock);

--- a/libursa/Task.cpp
+++ b/libursa/Task.cpp
@@ -20,7 +20,7 @@ std::string db_change_to_string(DbChangeType change) {
     return "<invalid?>";
 }
 
-bool TaskSpec::has_typed_lock(const DatasetLock &other) const {
+bool TaskSpec::has_lock(const DatasetLock &other) const {
     for (const auto &lock : locks_) {
         if (const auto *dslock = std::get_if<DatasetLock>(&lock)) {
             if (dslock->target() == other.target()) {
@@ -31,7 +31,7 @@ bool TaskSpec::has_typed_lock(const DatasetLock &other) const {
     return false;
 }
 
-bool TaskSpec::has_typed_lock(const IteratorLock &other) const {
+bool TaskSpec::has_lock(const IteratorLock &other) const {
     for (const auto &lock : locks_) {
         if (const auto *itlock = std::get_if<IteratorLock>(&lock)) {
             if (itlock->target() == other.target()) {
@@ -42,6 +42,12 @@ bool TaskSpec::has_typed_lock(const IteratorLock &other) const {
     return false;
 }
 
-bool TaskSpec::has_lock(const DatabaseLock &oth) const {
-    return std::visit([this](const auto &l) { return has_typed_lock(l); }, oth);
+uint64_t TaskSpec::mebibytes_locked() const {
+    uint64_t total_locked = 0;
+    for (const auto &lock : locks_) {
+        if (const auto *memlock = std::get_if<MemoryLock>(&lock)) {
+            total_locked += memlock->mebibytes();
+        }
+    }
+    return total_locked;
 }

--- a/libursa/Task.h
+++ b/libursa/Task.h
@@ -50,10 +50,6 @@ class TaskSpec {
     // Immutable vector of locks acquired by this task.
     std::vector<DatabaseLock> locks_;
 
-    // Helpers for std::visit
-    bool has_typed_lock(const DatasetLock &other) const;
-    bool has_typed_lock(const IteratorLock &other) const;
-
    public:
     TaskSpec(uint64_t id, std::string conn_id, std::string request_str,
              uint64_t epoch_ms, std::vector<DatabaseLock> locks)
@@ -81,7 +77,13 @@ class TaskSpec {
     uint64_t work_done() const { return work_done_; }
     const std::vector<DatabaseLock> &locks() const { return locks_; };
 
-    bool has_lock(const DatabaseLock &oth) const;
+    // Is the specified dataset locked by this task?
+    bool has_lock(const DatasetLock &other) const;
+
+    // Is the specified dataset locked by this task?
+    bool has_lock(const IteratorLock &other) const;
+
+    uint64_t mebibytes_locked() const;
 
     std::string hex_conn_id() const { return bin_str_to_hex(conn_id_); }
 


### PR DESCRIPTION
This implements a best-effort way to reduce database memory usage.
Every task will try to estimate necessary RAM, and won't start
executing if the memory is too scarce.