### PR TITLE
Fix iterator selects for filenames with spaces

### DIFF
--- a/libursa/OnDiskIterator.cpp
+++ b/libursa/OnDiskIterator.cpp
@@ -65,7 +65,7 @@ void OnDiskIterator::pop(int count, std::vector<std::string> *out) {
 
     for (int i = 0; i < count && !reader.eof(); i++) {
         std::string next;
-        reader >> next;
+        std::getline(reader, next);
         if (reader.eof()) {
             break;
         }

--- a/teste2e/test_select.py
+++ b/teste2e/test_select.py
@@ -23,6 +23,23 @@ def test_select_with_taints(ursadb: UrsadbTestContext):
     check_query(ursadb, 'with taints ["test", "other"] "test"', [])
 
 
+def test_select_with_weird_filenames(ursadb: UrsadbTestContext):
+    weird_names = [
+        "hmm hmm",
+        "hmm \" ' hmm",
+        "hmm \\ hmm",
+        "hmm $(ls) $$ $shell hmm",
+        "hmm <> hmm"
+    ]
+    store_files(
+        ursadb, "gram3", {
+            name: b"test" for name in weird_names
+        },
+    )
+
+    check_query(ursadb, '"test"', weird_names)
+
+
 def test_select_with_datasets(ursadb: UrsadbTestContext):
     store_files(
         ursadb, "gram3", {"first": b"test",},


### PR DESCRIPTION
Due to improper use of file read functions, iterator select didn't
work properly when filename contained spaces.