### PR TITLE
Fix index from list command

### DIFF
--- a/libursa/Daemon.cpp
+++ b/libursa/Daemon.cpp
@@ -85,10 +85,11 @@ Response execute_command(const IndexFromCommand &cmd, Task *task,
     }
 
     if (cmd.ensure_unique()) {
-        snap->index_files(task, cmd.get_index_types(), cmd.taints(), paths);
+        snap->recursive_index_paths(task, cmd.get_index_types(), cmd.taints(),
+                                    paths);
     } else {
-        snap->force_index_files(task, cmd.get_index_types(), cmd.taints(),
-                                paths);
+        snap->force_recursive_index_paths(task, cmd.get_index_types(),
+                                          cmd.taints(), paths);
     }
 
     return Response::ok();

--- a/libursa/DatabaseSnapshot.h
+++ b/libursa/DatabaseSnapshot.h
@@ -36,6 +36,18 @@ class DatabaseSnapshot {
     void internal_compact(Task *task,
                           std::vector<const OnDiskDataset *> datasets) const;
 
+    // Indexes files with given paths. Ensures that no file will be indexed
+    // twice - this may be a very memory-heavy operation.
+    void index_files(Task *task, const std::vector<IndexType> &types,
+                     const std::set<std::string> &taints,
+                     const std::vector<std::string> &filenames) const;
+
+    // Indexes files with given paths. Does not check for
+    // duplicated files, which makes if faster, but also more dangerous.
+    void force_index_files(Task *task, const std::vector<IndexType> &types,
+                           const std::set<std::string> &taints,
+                           const std::vector<std::string> &targets) const;
+
     // Internal function used to find both full and smart candidates.
     std::vector<std::string> find_compact_candidate(bool smart) const;
 
@@ -72,18 +84,6 @@ class DatabaseSnapshot {
         Task *task, const std::vector<IndexType> &types,
         const std::set<std::string> &taints,
         const std::vector<std::string> &root_paths) const;
-
-    // Indexes files with given paths. Ensures that no file will be indexed
-    // twice - this may be a very memory-heavy operation.
-    void index_files(Task *task, const std::vector<IndexType> &types,
-                     const std::set<std::string> &taints,
-                     const std::vector<std::string> &filenames) const;
-
-    // Indexes files with given paths. Does not check for
-    // duplicated files, which makes if faster, but also more dangerous.
-    void force_index_files(Task *task, const std::vector<IndexType> &types,
-                           const std::set<std::string> &taints,
-                           const std::vector<std::string> &targets) const;
 
     void reindex_dataset(Task *task, const std::vector<IndexType> &types,
                          const std::string &dataset_name) const;

--- a/teste2e/test_indexing.py
+++ b/teste2e/test_indexing.py
@@ -34,6 +34,17 @@ def test_indexing_big(ursadb: UrsadbTestContext):
     check_query(ursadb, '":hmm:"', [])
 
 
+def test_indexing_list(ursadb: UrsadbTestContext):
+    tmpdir = ursadb.tmpdir()
+    (tmpdir / "test").mkdir()
+    (tmpdir / "test" / "file").write_bytes(b"asdfgh")
+
+    (tmpdir / "list.txt").write_text(str(tmpdir / "test"))
+
+    ursadb.check_request(f"index from list \"{str(tmpdir / 'list.txt')}\";")
+    check_query(ursadb, '"asdfgh"', ["file"])
+
+
 def test_gram3_index_works_as_expected(ursadb: UrsadbTestContext):
     store_files(
         ursadb,


### PR DESCRIPTION
`index from list "/tmp/files.txt"` assumes all the paths are files, and this is not the expected behaviour. It was changed during the refactoring and not noticed until now.