### PR TITLE
Fix performance and accuracy for wide ascii strings

### DIFF
--- a/libursa/DatabaseSnapshot.cpp
+++ b/libursa/DatabaseSnapshot.cpp
@@ -233,7 +233,8 @@ QueryCounters DatabaseSnapshot::execute(const Query &query,
         }
     }
 
-    const QueryGraphCollection graphs{query, types_to_query, config};
+    Query query_copy{query.clone()};
+    query_copy.precompute(types_to_query, config);
 
     task->spec().estimate_work(datasets_to_query.size());
 
@@ -243,7 +244,7 @@ QueryCounters DatabaseSnapshot::execute(const Query &query,
         if (!ds->has_all_taints(taints)) {
             continue;
         }
-        ds->execute(graphs, out, &counters);
+        ds->execute(query_copy, out, &counters);
     }
     return counters;
 }

--- a/libursa/OnDiskDataset.h
+++ b/libursa/OnDiskDataset.h
@@ -15,17 +15,6 @@
 #include "ResultWriter.h"
 #include "Task.h"
 
-class QueryGraphCollection {
-    std::unordered_map<IndexType, QueryGraph> graphs_;
-
-   public:
-    QueryGraphCollection(const Query &query,
-                         const std::unordered_set<IndexType> &types,
-                         const DatabaseConfig &config);
-
-    const QueryGraph &get(IndexType type) const;
-};
-
 class OnDiskDataset {
     std::string name;
     fs::path db_base;
@@ -37,8 +26,7 @@ class OnDiskDataset {
         return taints == other.taints;
     }
     std::string get_file_name(FileId fid) const;
-    QueryResult query(const QueryGraphCollection &graphs,
-                      QueryCounters *counters) const;
+    QueryResult query(const Query &query, QueryCounters *counters) const;
     const OnDiskIndex &get_index_with_type(IndexType index_type) const;
     void drop_file(const std::string &fname) const;
 
@@ -54,7 +42,7 @@ class OnDiskDataset {
     }
     void toggle_taint(const std::string &taint);
     bool has_all_taints(const std::set<std::string> &taints) const;
-    void execute(const QueryGraphCollection &graphs, ResultWriter *out,
+    void execute(const Query &query, ResultWriter *out,
                  QueryCounters *counters) const;
     uint64_t get_file_count() const { return files_index->get_file_count(); }
     void for_each_filename(std::function<void(const std::string &)> cb) const {

--- a/libursa/OnDiskIndex.h
+++ b/libursa/OnDiskIndex.h
@@ -26,11 +26,6 @@ class OnDiskIndex {
     std::vector<FileId> query_primitive(TriGram trigram,
                                         QueryCounter *counter) const;
     std::pair<uint64_t, uint64_t> get_run_offsets(TriGram trigram) const;
-    bool internal_expand(QString::const_iterator qit, uint8_t *out, size_t pos,
-                         size_t comb_len, const TrigramGenerator &gen,
-                         QueryResult &res) const;
-    QueryResult expand_wildcards(const QString &qstr, size_t len,
-                                 const TrigramGenerator &gen) const;
 
     static void on_disk_merge_core(const std::vector<IndexMergeHelper> &indexes,
                                    RawFile *out, TaskSpec *task);

--- a/src/Tests.cpp
+++ b/src/Tests.cpp
@@ -52,12 +52,10 @@ QString mqs(const std::string &str) {
     return out;
 }
 
-QueryGraph mqg(const std::string &str, IndexType type) {
-    QString out;
-    for (const auto &c : str) {
-        out.emplace_back(QToken::single(c));
-    }
-    return q(std::move(out)).to_graph(type, DatabaseConfig());
+QueryGraph mqg(const std::string &str, IndexType ntype) {
+    TokenValidator validator = get_validator_for(ntype);
+    size_t input_len = get_ngram_size_for(ntype);
+    return to_query_graph(mqs(str), input_len, DatabaseConfig(), validator);
 }
 
 TEST_CASE("packing 3grams", "[internal]") {

--- a/teste2e/test_select.py
+++ b/teste2e/test_select.py
@@ -4,16 +4,12 @@ import pytest
 
 
 def test_select_with_taints(ursadb: UrsadbTestContext):
-    store_files(
-        ursadb, "gram3", {"tainted": b"test",},
-    )
+    store_files(ursadb, "gram3", {"tainted": b"test"})
 
     topology = ursadb.check_request("topology;")
     dsname = list(topology["result"]["datasets"].keys())[0]
 
-    store_files(
-        ursadb, "gram3", {"untainted": b"test",},
-    )
+    store_files(ursadb, "gram3", {"untainted": b"test"})
 
     ursadb.check_request(f'dataset "{dsname}" taint "test";')
 
@@ -29,40 +25,49 @@ def test_select_with_weird_filenames(ursadb: UrsadbTestContext):
         "hmm \" ' hmm",
         "hmm \\ hmm",
         "hmm $(ls) $$ $shell hmm",
-        "hmm <> hmm"
+        "hmm <> hmm",
     ]
-    store_files(
-        ursadb, "gram3", {
-            name: b"test" for name in weird_names
-        },
-    )
+    store_files(ursadb, "gram3", {name: b"test" for name in weird_names})
 
     check_query(ursadb, '"test"', weird_names)
 
 
 def test_select_with_datasets(ursadb: UrsadbTestContext):
-    store_files(
-        ursadb, "gram3", {"first": b"test",},
-    )
+    store_files(ursadb, "gram3", {"first": b"test"})
 
     topology = ursadb.check_request("topology;")
     dsname = list(topology["result"]["datasets"].keys())[0]
 
-    store_files(
-        ursadb, "gram3", {"second": b"test",},
-    )
+    store_files(ursadb, "gram3", {"second": b"test"})
 
     check_query(ursadb, f'with datasets ["{dsname}"] "test"', ["first"])
 
 
+def test_select_ascii_wide(ursadb: UrsadbTestContext):
+    # ensure that `ascii wide` strings don't produce too large results
+    store_files(
+        ursadb,
+        ["gram3", "text4", "wide8"],
+        {
+            "ascii": b"koty",
+            "wide": b"k\x00o\x00t\x00y\x00",
+            "falsepositive": b"k\x00o\x00???\x00o\x00t\x00y\x00",
+        },
+    )
+
+    check_query(ursadb, f'"koty"', ["ascii"])
+    check_query(ursadb, f'"k\\x00o\\x00t\\x00y\\x00"', ["wide"])
+    check_query(ursadb, f'("koty" | "k\\x00o\\x00t\\x00y\\x00")', ["ascii", "wide"])
+
+
 @pytest.mark.parametrize(
     "ursadb",
-    [UrsadbConfig(query_max_ngram=256*256, query_max_edge=255)],
+    [UrsadbConfig(query_max_ngram=256 * 256, query_max_edge=255)],
     indirect=["ursadb"],
 )
 def test_select_with_wildcards(ursadb: UrsadbTestContext):
     store_files(
-        ursadb, "gram3", {"first": b"first", "fiRst": b"fiRst", "second": b"second"},
+        ursadb, "gram3", {"first": b"first", "fiRst": b"fiRst", "second": b"second"}
     )
 
     check_query(ursadb, '"first"', ["first"])
@@ -70,21 +75,18 @@ def test_select_with_wildcards(ursadb: UrsadbTestContext):
     check_query(ursadb, '"fi\\x??st"', ["first", "fiRst"])
     check_query(ursadb, '"fi\\x?2st"', ["first", "fiRst"])
 
-    check_query(ursadb, '{66 69 72 73 74}', ["first"])
-    check_query(ursadb, '{66 69 52 73 74}', ["fiRst"])
-    check_query(ursadb, '{66 69 ?? 73 74}', ["first", "fiRst"])
-    check_query(ursadb, '{66 69 ?2 73 74}', ["first", "fiRst"])
-
+    check_query(ursadb, "{66 69 72 73 74}", ["first"])
+    check_query(ursadb, "{66 69 52 73 74}", ["fiRst"])
+    check_query(ursadb, "{66 69 ?? 73 74}", ["first", "fiRst"])
+    check_query(ursadb, "{66 69 ?2 73 74}", ["first", "fiRst"])
 
 
 @pytest.mark.parametrize(
-    "ursadb",
-    [UrsadbConfig(query_max_ngram=16, query_max_edge=16)],
-    indirect=["ursadb"],
+    "ursadb", [UrsadbConfig(query_max_ngram=16, query_max_edge=16)], indirect=["ursadb"]
 )
 def test_select_with_wildcards_with_limits(ursadb: UrsadbTestContext):
     store_files(
-        ursadb, "gram3", {"first": b"first", "fiRst": b"fiRst", "second": b"second"},
+        ursadb, "gram3", {"first": b"first", "fiRst": b"fiRst", "second": b"second"}
     )
 
     check_query(ursadb, '"first"', ["first"])
@@ -93,8 +95,8 @@ def test_select_with_wildcards_with_limits(ursadb: UrsadbTestContext):
     check_query(ursadb, '"fi\\x?2st"', ["first", "fiRst"])
     check_query(ursadb, '"fi\\x?2s\\x??"', ["first", "fiRst"])
 
-    check_query(ursadb, '{66 69 72 73 74}', ["first"])
-    check_query(ursadb, '{66 69 52 73 74}', ["fiRst"])
-    check_query(ursadb, '{66 69 ?? 73 74}', ["first", "fiRst", "second"])
-    check_query(ursadb, '{66 69 ?2 73 74}', ["first", "fiRst"])
-    check_query(ursadb, '{66 69 ?2 73 ??}', ["first", "fiRst"])
+    check_query(ursadb, "{66 69 72 73 74}", ["first"])
+    check_query(ursadb, "{66 69 52 73 74}", ["fiRst"])
+    check_query(ursadb, "{66 69 ?? 73 74}", ["first", "fiRst", "second"])
+    check_query(ursadb, "{66 69 ?2 73 74}", ["first", "fiRst"])
+    check_query(ursadb, "{66 69 ?2 73 ??}", ["first", "fiRst"])


### PR DESCRIPTION
Due to a refactoring earlier (probably), we started returning
many more results than we should. This commit should fix this,
without affecting performance negatively.