### PR TITLE
Fix regression when reducing minof queries to AND

### DIFF
--- a/libursa/QueryResult.cpp
+++ b/libursa/QueryResult.cpp
@@ -45,25 +45,20 @@ QueryResult QueryResult::do_min_of_real(
         return QueryResult::empty();
     }
 
-    // Special case optimisation for cutoff==1 and a single source.
-    if (cutoff == 1 && nontrivial_sources.size() == 1) {
-        return QueryResult(nontrivial_sources[0]->clone());
-    }
-
     // Special case optimisation - reduction to AND.
     if (cutoff == static_cast<int>(nontrivial_sources.size())) {
-        QueryResult out{QueryResult::everything()};
-        for (const auto &src : nontrivial_sources) {
-            out.results.do_and(*src);
+        QueryResult out{nontrivial_sources[0]->clone()};
+        for (int i = 1; i < nontrivial_sources.size(); i++) {
+            out.results.do_and(*nontrivial_sources[i]);
         }
         return out;
     }
 
     // Special case optimisation - reduction to OR.
     if (cutoff == 1) {
-        QueryResult out{QueryResult::empty()};
-        for (const auto &src : nontrivial_sources) {
-            out.results.do_or(*src);
+        QueryResult out{nontrivial_sources[0]->clone()};
+        for (int i = 1; i < nontrivial_sources.size(); i++) {
+            out.results.do_or(*nontrivial_sources[i]);
         }
         return out;
     }

--- a/teste2e/test_select.py
+++ b/teste2e/test_select.py
@@ -43,6 +43,12 @@ def test_select_with_datasets(ursadb: UrsadbTestContext):
     check_query(ursadb, f'with datasets ["{dsname}"] "test"', ["first"])
 
 
+def test_select_minof(ursadb: UrsadbTestContext):
+    store_files(ursadb, "gram3", {"aaaa": b"aaaa", "aaab": b"aaab", "aaac": b"aaac"})
+
+    check_query(ursadb, f'min 2 of ("aaa", "aab")', ["aaab"])
+
+
 def test_select_ascii_wide(ursadb: UrsadbTestContext):
     # ensure that `ascii wide` strings don't produce too large results
     store_files(


### PR DESCRIPTION
Could be reproduced with, for example

select min 2 of ("cat", "dog")

is_everything flag in QueryResult::do_min_of_real was never cleared