### PR TITLE
Docker improvements

### DIFF
--- a/.github/workflows/push_hub.yml
+++ b/.github/workflows/push_hub.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches:
     - master
+  schedule:
+    - cron: "24 04 1 * *"
 jobs:
   build_ursadb:
     name: Build image

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt update \
 RUN mkdir src && mkdir src/build
 COPY . src/
 WORKDIR /src/build
-RUN cmake -D CMAKE_CXX_COMPILER=/usr/bin/g++-7 -D CMAKE_BUILD_TYPE=Release .. && make
+RUN cmake -D CMAKE_CXX_COMPILER=/usr/bin/g++-7 -D CMAKE_BUILD_TYPE=Release .. && make -j$(nproc)
 
 FROM debian:buster
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,11 @@ COPY entrypoint.sh /entrypoint.sh
 
 RUN mkdir /var/lib/ursadb \
     && apt update && apt install -y libzmq3-dev dumb-init \
-    && chmod +x /entrypoint.sh /usr/bin/ursadb /usr/bin/ursadb_new
+    && chmod +x /entrypoint.sh /usr/bin/ursadb /usr/bin/ursadb_new \
+    && useradd -u 1000 -d /var/lib/ursadb ursa \
+    && chown -R ursa: /var/lib/ursadb /entrypoint.sh
+
+USER ursa
 
 EXPOSE 9281
 VOLUME ["/var/lib/ursadb"]


### PR DESCRIPTION
First of all, thanks guys for your work on the UrsaDB. We're currently implementing it in our own projects to speed up our yara-searches. 

However, we're aiming to use your docker images for running UrsaDB. Delving into this, we've seen that the Dockerhub UrsaDB is quite outdated (build may 2020) and does not follow some security considerations with regards to Docker images. Due to the fact mine organization is quite security minded I've added some additions.

1. Add automatic docker image rebuilds every first day of the month (04:24). This ensures that the image is build on the latest Debian image with the latest security patches. 
2. Ensure the UrsaDB process is run under a different user than root, (ursa 1000:1000)
3. Make building it a little faster by using `make` with multicore support. 