### PR TITLE
Fix Undefined Behaviour when getting a memory map size

### DIFF
--- a/libursa/MemMap.h
+++ b/libursa/MemMap.h
@@ -23,7 +23,7 @@ class MemMap {
 
     const uint8_t *data() const { return mmap_ptr; }
 
-    const size_t &size() const { return fsize; }
+    const size_t size() const { return fsize; }
 };
 
 class empty_file_error : public std::runtime_error {


### PR DESCRIPTION
This one is pretty critical bugfix and will probably hasten a new release.

Size method used to return a reference to a local variable. This is UB and it only works by accident. Turns out it doesn't work anymore with clang on architectures other than x86.

CC @chivay @patryk4815 and thanks for the help debugging.