### PR TITLE
Performance improvement 1: queryplans

### DIFF
--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -22,24 +22,6 @@ jobs:
       run: cmake --build build --target format
     - name: check formatting
       run: git diff --exit-code || ( >&2 echo "Please run 'make format' to fix these issues automatically." && false )
-  test_clang_tidy:
-    name: test clang tidy
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-    - name: checkout master
-      run: git fetch origin master
-    - name: install dependencies
-      run: sudo apt-get install -y clang-tidy libzmq3-dev
-    - name: find changed files
-      run: git diff origin/master --name-only "*.cpp" > /tmp/filestocheck && cat /tmp/filestocheck
-    - name: clang-tidy
-      run: if [ -s /tmp/filestocheck ]; then clang-tidy $(cat /tmp/filestocheck) -checks="google-*,performance-*" -fix -- -std=c++17 -I extern/ -I extern/spdlog/include/ -I.; fi
-    - name: FYI git diff
-      run: git diff
-      if: ${{ always() }}
   run_cmake_build:
     name: run cmake build
     runs-on: ubuntu-latest

--- a/libursa/DatabaseSnapshot.cpp
+++ b/libursa/DatabaseSnapshot.cpp
@@ -233,9 +233,7 @@ QueryCounters DatabaseSnapshot::execute(const Query &query,
         }
     }
 
-    Query query_copy{query.clone()};
-    query_copy.precompute(types_to_query, config);
-
+    Query plan = query.plan(types_to_query, config);
     task->spec().estimate_work(datasets_to_query.size());
 
     QueryCounters counters;
@@ -244,7 +242,7 @@ QueryCounters DatabaseSnapshot::execute(const Query &query,
         if (!ds->has_all_taints(taints)) {
             continue;
         }
-        ds->execute(query_copy, out, &counters);
+        ds->execute(plan, out, &counters);
     }
     return counters;
 }

--- a/libursa/DatabaseSnapshot.cpp
+++ b/libursa/DatabaseSnapshot.cpp
@@ -226,14 +226,6 @@ QueryCounters DatabaseSnapshot::execute(const Query &query,
         }
     }
 
-    std::unordered_set<IndexType> types_to_query;
-    for (const auto *ds : datasets_to_query) {
-        for (const auto &ndx : ds->get_indexes()) {
-            types_to_query.emplace(ndx.index_type());
-        }
-    }
-
-    Query plan = query.plan(types_to_query, config);
     task->spec().estimate_work(datasets_to_query.size());
 
     QueryCounters counters;
@@ -242,7 +234,7 @@ QueryCounters DatabaseSnapshot::execute(const Query &query,
         if (!ds->has_all_taints(taints)) {
             continue;
         }
-        ds->execute(plan, out, &counters);
+        ds->execute(query, out, &counters);
     }
     return counters;
 }

--- a/libursa/DatabaseSnapshot.cpp
+++ b/libursa/DatabaseSnapshot.cpp
@@ -352,7 +352,7 @@ void DatabaseSnapshot::compact_locked_datasets(Task *task) const {
 // After the merging, do more plumbing to add results to the task->changes
 // collection.
 void DatabaseSnapshot::internal_compact(
-    Task *task, std::vector<const OnDiskDataset *> datasets) const {
+    Task *task, const std::vector<const OnDiskDataset *> &datasets) const {
     std::vector<std::string> ds_names;
 
     // There's nothing to compact

--- a/libursa/DatabaseSnapshot.h
+++ b/libursa/DatabaseSnapshot.h
@@ -33,8 +33,8 @@ class DatabaseSnapshot {
 
     friend class Indexer;
 
-    void internal_compact(Task *task,
-                          std::vector<const OnDiskDataset *> datasets) const;
+    void internal_compact(
+        Task *task, const std::vector<const OnDiskDataset *> &datasets) const;
 
     // Indexes files with given paths. Ensures that no file will be indexed
     // twice - this may be a very memory-heavy operation.

--- a/libursa/OnDiskDataset.cpp
+++ b/libursa/OnDiskDataset.cpp
@@ -86,7 +86,7 @@ void OnDiskDataset::execute(const Query &query, ResultWriter *out,
     }
     const Query plan = query.plan(types_to_query);
 
-    QueryResult result = this->query(query, counters);
+    QueryResult result = this->query(plan, counters);
     if (result.is_everything()) {
         files_index->for_each_filename(
             [&out](const std::string &fname) { out->push_back(fname); });

--- a/libursa/OnDiskDataset.cpp
+++ b/libursa/OnDiskDataset.cpp
@@ -81,7 +81,7 @@ QueryResult OnDiskDataset::query(const Query &query,
 void OnDiskDataset::execute(const Query &query, ResultWriter *out,
                             QueryCounters *counters) const {
     std::unordered_set<IndexType> types_to_query;
-    for (const auto &ndx : ds->get_indexes()) {
+    for (const auto &ndx : get_indexes()) {
         types_to_query.emplace(ndx.index_type());
     }
     const Query plan = query.plan(types_to_query);

--- a/libursa/OnDiskDataset.cpp
+++ b/libursa/OnDiskDataset.cpp
@@ -73,13 +73,19 @@ QueryResult OnDiskDataset::query(const Query &query,
                     return ndx.query(primitive.trigram, counters);
                 }
             }
-            throw std::runtime_error("Unexpected graph type in query");
+            throw std::runtime_error("Unexpected ngram type in query");
         },
         counters);
 }
 
 void OnDiskDataset::execute(const Query &query, ResultWriter *out,
                             QueryCounters *counters) const {
+    std::unordered_set<IndexType> types_to_query;
+    for (const auto &ndx : ds->get_indexes()) {
+        types_to_query.emplace(ndx.index_type());
+    }
+    const Query plan = query.plan(types_to_query);
+
     QueryResult result = this->query(query, counters);
     if (result.is_everything()) {
         files_index->for_each_filename(

--- a/libursa/OnDiskDataset.cpp
+++ b/libursa/OnDiskDataset.cpp
@@ -67,17 +67,13 @@ std::string OnDiskDataset::get_file_name(FileId fid) const {
 QueryResult OnDiskDataset::query(const Query &query,
                                  QueryCounters *counters) const {
     return query.run(
-        [this](auto &graphs, QueryCounters *counters) {
-            QueryResult result = QueryResult::everything();
+        [this](PrimitiveQuery primitive, QueryCounters *counters) {
             for (auto &ndx : indices) {
-                if (graphs.count(ndx.index_type()) == 0) {
-                    throw std::runtime_error("Unexpected graph type in query");
+                if (ndx.index_type() == primitive.itype) {
+                    return ndx.query(primitive.trigram, counters);
                 }
-                auto subresult{
-                    ndx.query(graphs.at(ndx.index_type()), counters)};
-                result.do_and(subresult, &counters->ands());
             }
-            return result;
+            throw std::runtime_error("Unexpected graph type in query");
         },
         counters);
 }

--- a/libursa/OnDiskIndex.cpp
+++ b/libursa/OnDiskIndex.cpp
@@ -74,8 +74,7 @@ QueryResult OnDiskIndex::query(const QueryGraph &graph,
 }
 
 // Returns all files with a given ngram
-QueryResult OnDiskIndex::query(TriGram trigram,
-                               QueryCounters *counters) const {
+QueryResult OnDiskIndex::query(TriGram trigram, QueryCounters *counters) const {
     return QueryResult(std::move(query_primitive(trigram, &counters->reads())));
 }
 

--- a/libursa/OnDiskIndex.cpp
+++ b/libursa/OnDiskIndex.cpp
@@ -73,6 +73,12 @@ QueryResult OnDiskIndex::query(const QueryGraph &graph,
     return graph.run(oracle, counters);
 }
 
+// Returns all files with a given ngram
+QueryResult OnDiskIndex::query(TriGram trigram,
+                               QueryCounters *counters) const {
+    return QueryResult(std::move(query_primitive(trigram, &counters->reads())));
+}
+
 std::pair<uint64_t, uint64_t> OnDiskIndex::get_run_offsets(
     TriGram trigram) const {
     uint64_t ptrs[2];

--- a/libursa/OnDiskIndex.h
+++ b/libursa/OnDiskIndex.h
@@ -39,6 +39,7 @@ class OnDiskIndex {
     const fs::path &get_fpath() const { return fpath; }
     IndexType index_type() const { return ntype; }
     QueryResult query(const QueryGraph &graph, QueryCounters *counters) const;
+    QueryResult query(TriGram trigram, QueryCounters *counters) const;
     uint64_t real_size() const;
     static void on_disk_merge(const fs::path &db_base, const std::string &fname,
                               IndexType merge_type,

--- a/libursa/QString.h
+++ b/libursa/QString.h
@@ -37,6 +37,9 @@ class QToken {
     // Equivalent to `possible_values.size()`.
     uint64_t num_possible_values() const;
 
+    // Returns true, if the QToken is unique (has only one possible value)
+    bool unique() const { return opts_.size() == 1; }
+
     // Returns true, if the QToken is empty (doesn't accept any character).
     bool empty() const { return opts_.empty(); }
 

--- a/libursa/Query.cpp
+++ b/libursa/Query.cpp
@@ -273,12 +273,11 @@ std::vector<PrimitiveQuery> plan_qstring(
     return std::move(plan);
 }
 
-Query Query::plan(const std::unordered_set<IndexType> &types_to_query,
-                  const DatabaseConfig &config) const {
+Query Query::plan(const std::unordered_set<IndexType> &types_to_query) const {
     if (type != QueryType::PRIMITIVE) {
         std::vector<Query> plans;
         for (const auto &query : queries) {
-            plans.emplace_back(query.plan(types_to_query, config));
+            plans.emplace_back(query.plan(types_to_query));
         }
         if (type == QueryType::MIN_OF) {
             return Query(count, std::move(plans));

--- a/libursa/Query.cpp
+++ b/libursa/Query.cpp
@@ -218,7 +218,8 @@ QueryGraph to_query_graph(const QString &str, int size,
 // For primitive queries, find a minimal covering set of ngram queries and
 // return it. If there are multiple disconnected components, AND them.
 // For example, "abcde\x??efg" will return abcd & bcde & efg
-std::vector<PrimitiveQuery> plan_qstring(const std::unordered_set<IndexType> &types_to_query, const QString &value) {
+std::vector<PrimitiveQuery> plan_qstring(
+    const std::unordered_set<IndexType> &types_to_query, const QString &value) {
     std::vector<PrimitiveQuery> plan;
 
     bool has_gram3 = types_to_query.count(IndexType::GRAM3) != 0;

--- a/libursa/Query.h
+++ b/libursa/Query.h
@@ -19,23 +19,24 @@ enum class QueryType { PRIMITIVE = 1, AND = 2, OR = 3, MIN_OF = 4 };
 // This is different to the TriGram typedef, because TriGram doesn't know what
 // type of index it represents.
 class PrimitiveQuery {
-  public:
-    PrimitiveQuery(IndexType itype, TriGram trigram) :itype(itype), trigram(trigram) {
-    }
+   public:
+    PrimitiveQuery(IndexType itype, TriGram trigram)
+        : itype(itype), trigram(trigram) {}
 
     const IndexType itype;
     const TriGram trigram;
 };
 
-using QueryPrimitive = std::function<QueryResult(
-    PrimitiveQuery, QueryCounters *counter)>;
+using QueryPrimitive =
+    std::function<QueryResult(PrimitiveQuery, QueryCounters *counter)>;
 
 // Query represents the query as provided by the user.
 // Query can contain subqueries (using AND/OR/MINOF) or be a literal query.
-// There are actually two types of literal query objects - "plain" and "planned".
-// All queries start as plain - represented by QString. They are independent of
-// the database. Before actually running them, they must be planned (using a plan()
-// method). At this point query decides which ngrams will actually be checked.
+// There are actually two types of literal query objects - "plain" and
+// "planned". All queries start as plain - represented by QString. They are
+// independent of the database. Before actually running them, they must be
+// planned (using a plan() method). At this point query decides which ngrams
+// will actually be checked.
 class Query {
    private:
     Query(const Query &other)
@@ -51,7 +52,9 @@ class Query {
     }
 
     explicit Query(std::vector<PrimitiveQuery> &&query_plan)
-        : type(QueryType::PRIMITIVE), query_plan(std::move(query_plan)), value() {}
+        : type(QueryType::PRIMITIVE),
+          query_plan(std::move(query_plan)),
+          value() {}
 
    public:
     explicit Query(QString &&qstr);
@@ -69,15 +72,15 @@ class Query {
     QueryResult run(const QueryPrimitive &primitive,
                     QueryCounters *counters) const;
     Query plan(const std::unordered_set<IndexType> &types_to_query,
-                    const DatabaseConfig &config) const;
+               const DatabaseConfig &config) const;
 
     Query clone() const { return Query(*this); }
 
    private:
     QueryType type;
     // used for QueryType::PRIMITIVE
-    QString value;  // before plan()
-    std::vector<PrimitiveQuery> query_plan; // after plan()
+    QString value;                           // before plan()
+    std::vector<PrimitiveQuery> query_plan;  // after plan()
     // used for QueryType::MIN_OF
     uint32_t count;
     // used for QueryType::AND/OR/MIN_OF

--- a/libursa/Query.h
+++ b/libursa/Query.h
@@ -71,8 +71,7 @@ class Query {
 
     QueryResult run(const QueryPrimitive &primitive,
                     QueryCounters *counters) const;
-    Query plan(const std::unordered_set<IndexType> &types_to_query,
-               const DatabaseConfig &config) const;
+    Query plan(const std::unordered_set<IndexType> &types_to_query) const;
 
     Query clone() const { return Query(*this); }
 

--- a/libursa/Query.h
+++ b/libursa/Query.h
@@ -15,13 +15,31 @@
 
 enum class QueryType { PRIMITIVE = 1, AND = 2, OR = 3, MIN_OF = 4 };
 
-using QueryPrimitive = std::function<QueryResult(
-    const std::unordered_map<IndexType, QueryGraph> &, QueryCounters *counter)>;
+// Small utility class to represent a ngram along with its type.
+// This is different to the TriGram typedef, because TriGram doesn't know what
+// type of index it represents.
+class PrimitiveQuery {
+  public:
+    PrimitiveQuery(IndexType itype, TriGram trigram) :itype(itype), trigram(trigram) {
+    }
 
+    const IndexType itype;
+    const TriGram trigram;
+};
+
+using QueryPrimitive = std::function<QueryResult(
+    PrimitiveQuery, QueryCounters *counter)>;
+
+// Query represents the query as provided by the user.
+// Query can contain subqueries (using AND/OR/MINOF) or be a literal query.
+// There are actually two types of literal query objects - "plain" and "planned".
+// All queries start as plain - represented by QString. They are independent of
+// the database. Before actually running them, they must be planned (using a plan()
+// method). At this point query decides which ngrams will actually be checked.
 class Query {
    private:
     Query(const Query &other)
-        : type(other.type), value_graphs(), count(other.count) {
+        : type(other.type), query_plan(), count(other.count) {
         queries.reserve(other.queries.size());
         for (const auto &query : other.queries) {
             queries.emplace_back(query.clone());
@@ -31,6 +49,9 @@ class Query {
             value.emplace_back(token.clone());
         }
     }
+
+    explicit Query(std::vector<PrimitiveQuery> &&query_plan)
+        : type(QueryType::PRIMITIVE), query_plan(std::move(query_plan)), value() {}
 
    public:
     explicit Query(QString &&qstr);
@@ -47,16 +68,16 @@ class Query {
 
     QueryResult run(const QueryPrimitive &primitive,
                     QueryCounters *counters) const;
-    void precompute(const std::unordered_set<IndexType> &types_to_query,
-                    const DatabaseConfig &config);
+    Query plan(const std::unordered_set<IndexType> &types_to_query,
+                    const DatabaseConfig &config) const;
 
     Query clone() const { return Query(*this); }
 
    private:
     QueryType type;
     // used for QueryType::PRIMITIVE
-    QString value;
-    std::unordered_map<IndexType, QueryGraph> value_graphs;
+    QString value;  // before plan()
+    std::vector<PrimitiveQuery> query_plan; // after plan()
     // used for QueryType::MIN_OF
     uint32_t count;
     // used for QueryType::AND/OR/MIN_OF

--- a/libursa/Utils.cpp
+++ b/libursa/Utils.cpp
@@ -103,17 +103,18 @@ std::optional<TriGram> convert_gram(IndexType type, uint64_t source) {
     return std::make_optional(result[0]);
 }
 
-std::optional<TriGram> convert_gram(IndexType type, int index, const QString &string) {
+std::optional<TriGram> convert_gram(IndexType type, int index,
+                                    const QString &string) {
     int size = get_ngram_size_for(type);
     if (index + size > string.size()) {
         return std::nullopt;
     }
     uint64_t source = 0;
     for (int i = 0; i < size; i++) {
-        if (!string[index+i].unique()) {
+        if (!string[index + i].unique()) {
             return std::nullopt;
         }
-        source = (source << 8) | string[index+i].possible_values()[0];
+        source = (source << 8) | string[index + i].possible_values()[0];
     }
     return convert_gram(type, source);
 }

--- a/libursa/Utils.cpp
+++ b/libursa/Utils.cpp
@@ -103,6 +103,21 @@ std::optional<TriGram> convert_gram(IndexType type, uint64_t source) {
     return std::make_optional(result[0]);
 }
 
+std::optional<TriGram> convert_gram(IndexType type, int index, const QString &string) {
+    int size = get_ngram_size_for(type);
+    if (index + size > string.size()) {
+        return std::nullopt;
+    }
+    uint64_t source = 0;
+    for (int i = 0; i < size; i++) {
+        if (!string[index+i].unique()) {
+            return std::nullopt;
+        }
+        source = (source << 8) | string[index+i].possible_values()[0];
+    }
+    return convert_gram(type, source);
+}
+
 void gen_b64grams(const uint8_t *mem, uint64_t size,
                   const TrigramCallback &cb) {
     if (size < 4) {

--- a/libursa/Utils.h
+++ b/libursa/Utils.h
@@ -46,7 +46,8 @@ void combinations(const QString &qstr, size_t len, const TrigramGenerator &gen,
 
 // Converts ngram from raw representation to compressed 3byte id.
 std::optional<TriGram> convert_gram(IndexType type, uint64_t source);
-std::optional<TriGram> convert_gram(IndexType type, int index, const QString &string);
+std::optional<TriGram> convert_gram(IndexType type, int index,
+                                    const QString &string);
 
 template <TrigramGenerator gen>
 std::vector<TriGram> get_trigrams_eager(const uint8_t *mem, size_t size) {

--- a/libursa/Utils.h
+++ b/libursa/Utils.h
@@ -46,6 +46,7 @@ void combinations(const QString &qstr, size_t len, const TrigramGenerator &gen,
 
 // Converts ngram from raw representation to compressed 3byte id.
 std::optional<TriGram> convert_gram(IndexType type, uint64_t source);
+std::optional<TriGram> convert_gram(IndexType type, int index, const QString &string);
 
 template <TrigramGenerator gen>
 std::vector<TriGram> get_trigrams_eager(const uint8_t *mem, size_t size) {

--- a/src/Benchmark.cpp
+++ b/src/Benchmark.cpp
@@ -15,7 +15,7 @@
 #include "libursa/Utils.h"
 
 template <typename F, typename... Args>
-static uint64_t benchmark_ms(F &&func, Args &&...args) {
+static uint64_t benchmark_ms(F &&func, Args &&... args) {
     auto start = std::chrono::steady_clock::now();
     std::forward<decltype(func)>(func)(std::forward<Args>(args)...);
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(

--- a/src/Benchmark.cpp
+++ b/src/Benchmark.cpp
@@ -15,7 +15,7 @@
 #include "libursa/Utils.h"
 
 template <typename F, typename... Args>
-static uint64_t benchmark_ms(F &&func, Args &&... args) {
+static uint64_t benchmark_ms(F &&func, Args &&...args) {
     auto start = std::chrono::steady_clock::now();
     std::forward<decltype(func)>(func)(std::forward<Args>(args)...);
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(

--- a/teste2e/test_indexing.py
+++ b/teste2e/test_indexing.py
@@ -98,7 +98,7 @@ def test_wide8_index_works_as_expected(ursadb: UrsadbTestContext):
     check_query(
         ursadb,
         "{61 (00|01) (62|63) (00|01) (63|62) (00|01) 64 00}",
-        ["vvv", "qqq"],
+        ["kot", "zzz", "yyy", "vvv", "qqq"],
     )
     assert get_index_hash(ursadb, "wide8")[:16] == "c73b55c36445ca6b"
 

--- a/teste2e/test_select.py
+++ b/teste2e/test_select.py
@@ -99,7 +99,7 @@ def test_select_with_wildcards_with_limits(ursadb: UrsadbTestContext):
     check_query(ursadb, '"fiRst"', ["fiRst"])
     check_query(ursadb, '"fi\\x??st"', ["first", "fiRst", "second"])
     check_query(ursadb, '"fi\\x?2st"', ["first", "fiRst", "second"])
-    check_query(ursadb, '"fi\\x?2s\\x??"', ["first", "fiRst"])
+    check_query(ursadb, '"fi\\x?2s\\x??"', ["first", "fiRst", "second"])
 
     check_query(ursadb, "{66 69 72 73 74}", ["first"])
     check_query(ursadb, "{66 69 52 73 74}", ["fiRst"])

--- a/teste2e/test_select.py
+++ b/teste2e/test_select.py
@@ -78,13 +78,13 @@ def test_select_with_wildcards(ursadb: UrsadbTestContext):
 
     check_query(ursadb, '"first"', ["first"])
     check_query(ursadb, '"fiRst"', ["fiRst"])
-    check_query(ursadb, '"fi\\x??st"', ["first", "fiRst"])
-    check_query(ursadb, '"fi\\x?2st"', ["first", "fiRst"])
+    check_query(ursadb, '"fi\\x??st"', ["first", "fiRst", "second"])
+    check_query(ursadb, '"fi\\x?2st"', ["first", "fiRst", "second"])
 
     check_query(ursadb, "{66 69 72 73 74}", ["first"])
     check_query(ursadb, "{66 69 52 73 74}", ["fiRst"])
-    check_query(ursadb, "{66 69 ?? 73 74}", ["first", "fiRst"])
-    check_query(ursadb, "{66 69 ?2 73 74}", ["first", "fiRst"])
+    check_query(ursadb, "{66 69 ?? 73 74}", ["first", "fiRst", "second"])
+    check_query(ursadb, "{66 69 ?2 73 74}", ["first", "fiRst", "second"])
 
 
 @pytest.mark.parametrize(
@@ -98,11 +98,11 @@ def test_select_with_wildcards_with_limits(ursadb: UrsadbTestContext):
     check_query(ursadb, '"first"', ["first"])
     check_query(ursadb, '"fiRst"', ["fiRst"])
     check_query(ursadb, '"fi\\x??st"', ["first", "fiRst", "second"])
-    check_query(ursadb, '"fi\\x?2st"', ["first", "fiRst"])
+    check_query(ursadb, '"fi\\x?2st"', ["first", "fiRst", "second"])
     check_query(ursadb, '"fi\\x?2s\\x??"', ["first", "fiRst"])
 
     check_query(ursadb, "{66 69 72 73 74}", ["first"])
     check_query(ursadb, "{66 69 52 73 74}", ["fiRst"])
     check_query(ursadb, "{66 69 ?? 73 74}", ["first", "fiRst", "second"])
-    check_query(ursadb, "{66 69 ?2 73 74}", ["first", "fiRst"])
-    check_query(ursadb, "{66 69 ?2 73 ??}", ["first", "fiRst"])
+    check_query(ursadb, "{66 69 ?2 73 74}", ["first", "fiRst", "second"])
+    check_query(ursadb, "{66 69 ?2 73 ??}", ["first", "fiRst", "second"])


### PR DESCRIPTION
While "Query Plans" sound like an advanced feature, this is actually an regression from QueryGraphs. Even more - after this PR query graphs will be unused and we could remove them in principle.

This PR reduces the number of reads between 10% and 300%. As seen on this screenshot (ignore time in `ms`, it's related to disk load and cache contents at the benchmark moment - read count is what matters):

![image](https://user-images.githubusercontent.com/7026881/207446268-d22662e7-afdd-4faa-a536-2cf20cf9b2f7.png)
 
Since read is the most time consuming part of ursadb work, especially on HDD, this may speed up the database significantly.

In this PR I rewrite the matching algorithm to use a minimal covering set of necessary ngrams. For example, to match:

```
abcde?ghi
```

(where ? in an unknown/missing character), we will check the following ngrams (assuming all indexes are available):

```
abcd
 bcde
      ghi
```

While in the past we would check:

```
abcd
 bcde
abc
 bcd
  cde
abcd (hash4)
 bcde (hash4)
      ghi
```

and AND the results later. most of these are unnecessary - for example there's no point checking 3grams `abc` and `bcd` since they're implied by 4gram `abcd`. The same goes for pseudo-4gram `abcd` provided by the hash4 index - it's implied by text4 one.

The downside is that it's hard to combine this with querygraphs. As mentioned in the PR introducing querygraphs, they're a nice data structure that enables a lot of optimisation - but I never did follow up, so they're quite slow in practice. The only thing we use them for right now are `nocase` strings. In this case this PR introduces a regression (nocase strings are ignored again). I think this is worth it for a much better performance in a general case.

Full benchmark results here: https://raw.githubusercontent.com/msm-code/ursa-bench/master/results/hdd_all.html (download and open with a browser of your choice).