### PR TITLE
Performance improvement 3: simplify queries

### DIFF
--- a/libursa/Query.cpp
+++ b/libursa/Query.cpp
@@ -280,6 +280,11 @@ Query Query::plan(const std::unordered_set<IndexType> &types_to_query) const {
             plans.emplace_back(query.plan(types_to_query));
         }
         if (type == QueryType::MIN_OF) {
+            if (count == 1) {
+                return Query(QueryType::OR, std::move(plans));
+            } else if (count == plans.size()) {
+                return Query(QueryType::AND, std::move(plans));
+            }
             return Query(count, std::move(plans));
         }
         return Query(type, std::move(plans));

--- a/libursa/Query.h
+++ b/libursa/Query.h
@@ -39,8 +39,7 @@ using QueryPrimitive =
 // will actually be checked.
 class Query {
    private:
-    Query(const Query &other)
-        : type(other.type), query_plan(), count(other.count) {
+    Query(const Query &other) : type(other.type), ngram(), count(other.count) {
         queries.reserve(other.queries.size());
         for (const auto &query : other.queries) {
             queries.emplace_back(query.clone());
@@ -51,10 +50,8 @@ class Query {
         }
     }
 
-    explicit Query(std::vector<PrimitiveQuery> &&query_plan)
-        : type(QueryType::PRIMITIVE),
-          query_plan(std::move(query_plan)),
-          value() {}
+    explicit Query(PrimitiveQuery ngram)
+        : type(QueryType::PRIMITIVE), ngram(ngram), value() {}
 
    public:
     explicit Query(QString &&qstr);
@@ -78,8 +75,8 @@ class Query {
    private:
     QueryType type;
     // used for QueryType::PRIMITIVE
-    QString value;                           // before plan()
-    std::vector<PrimitiveQuery> query_plan;  // after plan()
+    QString value;                        // before plan()
+    std::optional<PrimitiveQuery> ngram;  // after plan()
     // used for QueryType::MIN_OF
     uint32_t count;
     // used for QueryType::AND/OR/MIN_OF


### PR DESCRIPTION
I'm a bit disasppointed in this PR - TBH I expected another big win, while it turned out to be mediocre.

Nevertheless there are some improvements here, and the code is not too complex, so I think it's worth merging (I rejected a few ideas that turned out to be complex to implement for almost zero benefit).

As usual, results can be seen in this repo: https://github.com/msm-code/ursa-bench temporarily hosted here: http://65.21.130.153:8000/hdd_all.html

Ok, but what's going on in the code?

Basically we flatten queries:

```
AND(AND("A", "B"), AND("C", "D")) becomes AND("A", "B", "C", "D").
OR(OR("A", "B"), OR("C", "D")) becomes OR("A", "B", "C", "D").
```

And we handle minof special cases:

```
1 of ("A", "B") becomes OR("A", "B")
2 of ("A", "B") becomes AND("A", "B")
```

(should be merged after improvements 2)