### PR TITLE
Implement counter of unique ngram reads

### DIFF
--- a/libursa/OnDiskDataset.cpp
+++ b/libursa/OnDiskDataset.cpp
@@ -66,14 +66,13 @@ std::string OnDiskDataset::get_file_name(FileId fid) const {
 
 QueryResult OnDiskDataset::query(const Query &query,
                                  QueryCounters *counters) const {
-    std::set<PrimitiveQuery> uniq_ngrams;
+    std::set<PrimitiveQuery> seen;
     return query.run(
-        [this, &uniq_ngrams](PrimitiveQuery primitive,
-                             QueryCounters *counters) {
+        [this, &seen](PrimitiveQuery primitive, QueryCounters *counters) {
             std::optional<QueryOperation> operation;
-            if (uniq_ngrams.count(primitive) == 0) {
+            if (seen.count(primitive) == 0) {
                 operation = std::make_optional(&counters->uniq_reads());
-                uniq_ngrams.insert(primitive);
+                seen.insert(primitive);
             }
             for (auto &ndx : indices) {
                 if (ndx.index_type() == primitive.itype) {

--- a/libursa/OnDiskDataset.cpp
+++ b/libursa/OnDiskDataset.cpp
@@ -66,8 +66,12 @@ std::string OnDiskDataset::get_file_name(FileId fid) const {
 
 QueryResult OnDiskDataset::query(const Query &query,
                                  QueryCounters *counters) const {
+    std::set<uint32_t> uniq_ngrams;
     return query.run(
-        [this](PrimitiveQuery primitive, QueryCounters *counters) {
+        [this, &uniq_ngrams](PrimitiveQuery primitive, QueryCounters *counters) {
+            uint32_t rawgram = ((uint32_t)primitive.trigram) + ((uint32_t)primitive.itype << 24);
+            QueryCounters dummy;
+            QueryOperation op(&(uniq_ngrams.count(rawgram) > 0 ? &dummy : counters)->uniq_reads());
             for (auto &ndx : indices) {
                 if (ndx.index_type() == primitive.itype) {
                     return ndx.query(primitive.trigram, counters);

--- a/libursa/OnDiskDataset.cpp
+++ b/libursa/OnDiskDataset.cpp
@@ -71,8 +71,9 @@ QueryResult OnDiskDataset::query(const Query &query,
         [this, &uniq_ngrams](PrimitiveQuery primitive,
                              QueryCounters *counters) {
             std::optional<QueryOperation> operation;
-            if (uniq_ngrams.count(primitive) > 0) {
+            if (uniq_ngrams.count(primitive) == 0) {
                 operation = std::make_optional(&counters->uniq_reads());
+                uniq_ngrams.insert(primitive);
             }
             for (auto &ndx : indices) {
                 if (ndx.index_type() == primitive.itype) {

--- a/libursa/Query.cpp
+++ b/libursa/Query.cpp
@@ -3,6 +3,16 @@
 #include "Utils.h"
 #include "spdlog/spdlog.h"
 
+bool PrimitiveQuery::operator<(const PrimitiveQuery &rhs) const {
+    if (itype < rhs.itype) {
+        return true;
+    };
+    if (itype > rhs.itype) {
+        return false;
+    };
+    return trigram < rhs.trigram;
+}
+
 const std::vector<Query> &Query::as_queries() const {
     if (type != QueryType::AND && type != QueryType::OR &&
         type != QueryType::MIN_OF) {

--- a/libursa/Query.h
+++ b/libursa/Query.h
@@ -25,6 +25,10 @@ class PrimitiveQuery {
 
     const IndexType itype;
     const TriGram trigram;
+
+    // We want to use PrimitiveQuery in STL containers, and this means they
+    // must be comparable using <. Specific order doesn't matter.
+    bool operator<(const PrimitiveQuery &rhs) const;
 };
 
 using QueryPrimitive =

--- a/libursa/QueryCounters.cpp
+++ b/libursa/QueryCounters.cpp
@@ -20,7 +20,7 @@ std::unordered_map<std::string, QueryCounter> QueryCounters::counters() const {
     result["or"] = ors_;
     result["and"] = ands_;
     result["read"] = reads_;
-    result["uniq_read"] = reads_;
+    result["uniq_read"] = uniq_reads_;
     result["minof"] = minofs_;
     return result;
 }

--- a/libursa/QueryCounters.cpp
+++ b/libursa/QueryCounters.cpp
@@ -11,6 +11,7 @@ void QueryCounters::add(const QueryCounters &other) {
     ors_.add(other.ors_);
     ands_.add(other.ands_);
     reads_.add(other.reads_);
+    uniq_reads_.add(other.uniq_reads_);
     minofs_.add(other.minofs_);
 }
 
@@ -19,6 +20,7 @@ std::unordered_map<std::string, QueryCounter> QueryCounters::counters() const {
     result["or"] = ors_;
     result["and"] = ands_;
     result["read"] = reads_;
+    result["uniq_read"] = reads_;
     result["minof"] = minofs_;
     return result;
 }

--- a/libursa/QueryCounters.h
+++ b/libursa/QueryCounters.h
@@ -51,6 +51,9 @@ class QueryCounters {
     // Counter for file reads.
     QueryCounter reads_;
 
+    // Counter for unique file reads.
+    QueryCounter uniq_reads_;
+
     // Counter for min ... of operations.
     QueryCounter minofs_;
 
@@ -58,11 +61,9 @@ class QueryCounters {
     QueryCounters() : reads_{} {}
 
     QueryCounter &ands() { return ands_; }
-
     QueryCounter &ors() { return ors_; }
-
     QueryCounter &reads() { return reads_; }
-
+    QueryCounter &uniq_reads() { return uniq_reads_; }
     QueryCounter &minofs() { return minofs_; }
 
     void add(const QueryCounters &other);


### PR DESCRIPTION
Fixes #198.

This code adds tracking of unique ngram reads. This is the most important performance metrics on slow disks, so it'll be quite useful for future performance improvements.

Implementation-wise it's quite simple, the only nontrivial part is that I had to add operator< for PrimitiveQuery to put it into set::set.