### PR TITLE
Performance improvement 3: ngram profiles

### DIFF
--- a/libursa/Database.h
+++ b/libursa/Database.h
@@ -16,8 +16,16 @@ class Database {
     fs::path db_name;
     fs::path db_base;
     std::map<std::string, OnDiskIterator> iterators;
+    // Datasets that are a part of database. New tasks will only use working
+    // datasets for their operations.
     std::vector<OnDiskDataset *> working_datasets;
+    // Datasets that are loaded into memory (probably used by at least one
+    // task running in the db). We can't always unload dataset immediately
+    // after dropping it, because it may be used by a task.
     std::vector<std::unique_ptr<OnDiskDataset>> loaded_datasets;
+    // Ngram profile is a set of heuristic information about the "expected"
+    // relative sizes of data related to various ngrams.
+    NgramProfile profile;
     DatabaseConfig config_;
 
     uint64_t last_task_id;

--- a/libursa/DatabaseSnapshot.cpp
+++ b/libursa/DatabaseSnapshot.cpp
@@ -13,13 +13,14 @@ DatabaseSnapshot::DatabaseSnapshot(
     fs::path db_name, fs::path db_base, DatabaseConfig config,
     std::map<std::string, OnDiskIterator> iterators,
     std::vector<const OnDiskDataset *> datasets,
-    std::unordered_map<uint64_t, TaskSpec> tasks)
+    std::unordered_map<uint64_t, TaskSpec> tasks, const NgramProfile *profile)
     : db_name(std::move(db_name)),
       db_base(std::move(db_base)),
       iterators(std::move(iterators)),
       config(std::move(config)),
       datasets(std::move(datasets)),
-      tasks(std::move(tasks)) {}
+      tasks(std::move(tasks)),
+      profile(profile) {}
 
 const OnDiskDataset *DatabaseSnapshot::find_dataset(
     const std::string &name) const {
@@ -234,7 +235,7 @@ QueryCounters DatabaseSnapshot::execute(const Query &query,
         if (!ds->has_all_taints(taints)) {
             continue;
         }
-        ds->execute(query, out, &counters);
+        ds->execute(query, out, &counters, *profile);
     }
     return counters;
 }

--- a/libursa/DatabaseSnapshot.h
+++ b/libursa/DatabaseSnapshot.h
@@ -22,6 +22,7 @@ class DatabaseSnapshot {
     std::map<std::string, OnDiskIterator> iterators;
     DatabaseConfig config;
     std::vector<const OnDiskDataset *> datasets;
+    const NgramProfile *profile;
     std::set<std::string> locked_datasets;
     std::set<std::string> locked_iterators;
     std::unordered_map<uint64_t, TaskSpec> tasks;
@@ -57,7 +58,8 @@ class DatabaseSnapshot {
     DatabaseSnapshot(fs::path db_name, fs::path db_base, DatabaseConfig config,
                      std::map<std::string, OnDiskIterator> iterators,
                      std::vector<const OnDiskDataset *> datasets,
-                     std::unordered_map<uint64_t, TaskSpec> tasks);
+                     std::unordered_map<uint64_t, TaskSpec> tasks,
+                     const NgramProfile *profile);
 
     DatabaseName derive_name(const DatabaseName &original,
                              const std::string &type) const {

--- a/libursa/OnDiskDataset.cpp
+++ b/libursa/OnDiskDataset.cpp
@@ -11,6 +11,10 @@
 #include "spdlog/spdlog.h"
 
 uint64_t NgramProfile::size_in_bytes(PrimitiveQuery primitive) const {
+    if (profiles.empty()) {
+        // The profile is empty - return the same estimate for everything.
+        return 0;
+    }
     for (auto &[key, profile] : profiles) {
         if (key == primitive.itype) {
             return profile.at(primitive.trigram + 1) -

--- a/libursa/OnDiskDataset.h
+++ b/libursa/OnDiskDataset.h
@@ -31,6 +31,8 @@ class NgramProfile {
     NgramProfile() : profiles() {}
     NgramProfile(std::map<IndexType, std::vector<uint64_t>> &&profiles)
         : profiles(std::move(profiles)) {}
+    NgramProfile &operator=(NgramProfile &&other) = default;
+    NgramProfile(NgramProfile &&other) = default;
     NgramProfile(const NgramProfile &other) = delete;
 
     // Returns the size in bytes of data for a given ngram.

--- a/libursa/OnDiskIndex.cpp
+++ b/libursa/OnDiskIndex.cpp
@@ -109,6 +109,11 @@ uint64_t find_max_batch(const std::vector<IndexMergeHelper> &indexes,
     return NUM_TRIGRAMS - trigram;
 }
 
+uint64_t OnDiskIndex::run_size_in_bytes(TriGram trigram) const {
+    auto [start, end] = get_run_offsets(trigram);
+    return end - start;
+}
+
 // Merge the indexes, and stream the results to the `out` stream immediately.
 // This function tries to batch reads, which makes it much more efficient on
 // HDDs (on SSDs the difference is not noticeable).

--- a/libursa/OnDiskIndex.h
+++ b/libursa/OnDiskIndex.h
@@ -37,6 +37,9 @@ class OnDiskIndex {
     const std::string &get_fname() const { return fname; }
     const fs::path &get_fpath() const { return fpath; }
     IndexType index_type() const { return ntype; }
+
+    // Gets a run size of the given trigram in bytes.
+    uint64_t run_size_in_bytes(TriGram trigram) const;
     QueryResult query(TriGram trigram, QueryCounters *counters) const;
     uint64_t real_size() const;
     static void on_disk_merge(const fs::path &db_base, const std::string &fname,

--- a/libursa/Query.cpp
+++ b/libursa/Query.cpp
@@ -181,11 +181,12 @@ std::vector<PrimitiveQuery> plan_qstring(
     return std::move(plan);
 }
 
-Query Query::plan(const std::unordered_set<IndexType> &types_to_query) const {
+Query Query::plan(const std::unordered_set<IndexType> &types_to_query,
+                  const PrimitiveEvaluator &evaluate) const {
     if (type != QueryType::PRIMITIVE) {
         std::vector<Query> plans;
         for (const auto &query : queries) {
-            plans.emplace_back(query.plan(types_to_query));
+            plans.emplace_back(query.plan(types_to_query, evaluate));
         }
         if (type == QueryType::MIN_OF) {
             return Query(count, std::move(plans));
@@ -193,7 +194,11 @@ Query Query::plan(const std::unordered_set<IndexType> &types_to_query) const {
         return Query(type, std::move(plans));
     }
 
-    return Query(plan_qstring(types_to_query, value));
+    std::vector<PrimitiveQuery> plan = plan_qstring(types_to_query, value);
+    std::sort(plan.begin(), plan.end(), [&evaluate](auto l, auto r) {
+        return evaluate(l) < evaluate(r);
+    });
+    return Query(std::move(plan));
 }
 
 QueryResult Query::run(const QueryPrimitive &primitive,

--- a/libursa/Query.h
+++ b/libursa/Query.h
@@ -24,6 +24,10 @@ class PrimitiveQuery {
 
     IndexType itype;
     TriGram trigram;
+
+    // We want to use PrimitiveQuery in STL containers, and this means they
+    // must be comparable using <. Specific order doesn't matter.
+    bool operator<(const PrimitiveQuery &rhs) const;
 };
 
 using QueryPrimitive =

--- a/libursa/Query.h
+++ b/libursa/Query.h
@@ -22,16 +22,17 @@ class PrimitiveQuery {
     PrimitiveQuery(IndexType itype, TriGram trigram)
         : itype(itype), trigram(trigram) {}
 
-    const IndexType itype;
-    const TriGram trigram;
-
-    // We want to use PrimitiveQuery in STL containers, and this means they
-    // must be comparable using <. Specific order doesn't matter.
-    bool operator<(const PrimitiveQuery &rhs) const;
+    IndexType itype;
+    TriGram trigram;
 };
 
 using QueryPrimitive =
     std::function<QueryResult(PrimitiveQuery, QueryCounters *counter)>;
+
+// Type of function used to evaluate a given PrimitiveQuery.
+// The lower the result is, the smaller the (expected) size of the result
+// is and the higher priority of the given ngram should be.
+using PrimitiveEvaluator = std::function<uint32_t(PrimitiveQuery)>;
 
 // Query represents the query as provided by the user.
 // Query can contain subqueries (using AND/OR/MINOF) or be a literal query.
@@ -62,7 +63,8 @@ class Query {
 
     QueryResult run(const QueryPrimitive &primitive,
                     QueryCounters *counters) const;
-    Query plan(const std::unordered_set<IndexType> &types_to_query) const;
+    Query plan(const std::unordered_set<IndexType> &types_to_query,
+               const PrimitiveEvaluator &evaluate) const;
 
    private:
     QueryType type;


### PR DESCRIPTION
I'm not super happy with this change, but it gives good results.

So what we have here is a heuristic to estimate how many files match for a given ngram. We prefer to start with queries that will return a smaller number of files (because there is a chance that we can "fail fast" and return from a sub query without doing all the work).

So this PR introduces a class called NgramProfile, that stores this information. This is additional 128MB of memory footprint per database, but it shouldn't matter too much in the real world (I hope).

TODO: maybe we should make this optional?
TODO: do we need a way to regenerate the profile?
TODO: measure the real world impact (on cold and warm RAM) and assess the results. It complicates the code significantly, so I think we need at least 25% speedup to consider merging it.