### PR TITLE
Implement GC for iterators

### DIFF
--- a/libursa/Database.cpp
+++ b/libursa/Database.cpp
@@ -198,7 +198,7 @@ void Database::collect_stale_iterators() {
             if (can_acquire(lock)) {
                 // Iterator is not locked, so it's unused, so we can free it.
                 // Yes, in theory this is a race condition. But we can't acquire
-                // a new lock here since we don't know a task, and chance of
+                // a new lock here since we don't know the task, and chance of
                 // this happening is extremely slim (iterator would have to be
                 // used in exactly right millisecond after days of inactivity).
                 iterator_drop_list.push_back(itername);

--- a/libursa/Database.cpp
+++ b/libursa/Database.cpp
@@ -183,8 +183,13 @@ void Database::destroy_dataset(const std::string &dsname) {
 }
 
 void Database::collect_stale_iterators() {
-    std::vector<std::string> iterator_drop_list;
     uint64_t iterator_gc_seconds = config_.get(ConfigKey::iterator_gc_seconds());
+    if (iterator_gc_seconds == 0) {
+        // Zero means that GC is disabled.
+        return;
+    }
+
+    std::vector<std::string> iterator_drop_list;
     std::time_t now = std::time(nullptr);
     for (const auto &[itername, iter] : iterators) {
         if (now - iter.get_last_read_time() > iterator_gc_seconds) {

--- a/libursa/Database.cpp
+++ b/libursa/Database.cpp
@@ -182,6 +182,34 @@ void Database::destroy_dataset(const std::string &dsname) {
     }
 }
 
+void Database::collect_stale_iterators() {
+    std::vector<std::string> iterator_drop_list;
+    uint64_t iterator_gc_seconds = config_.get(ConfigKey::iterator_gc_seconds());
+    std::time_t now = std::time(nullptr);
+    for (const auto &[itername, iter] : iterators) {
+        if (now - iter.get_last_read_time() > iterator_gc_seconds) {
+            auto lock = IteratorLock(itername);
+            if (can_acquire(lock)) {
+                // Iterator is not locked, so it's unused, so we can free it.
+                // Yes, in theory this is a race condition. But we can't acquire
+                // a new lock here since we don't know a task, and chance of
+                // this happening is extremely slim (iterator would have to be
+                // used in exactly right millisecond after days of inactivity).
+                iterator_drop_list.push_back(itername);
+            }
+        }
+    }
+
+    for (const auto &itername : iterator_drop_list) {
+        iterators.at(itername).drop();
+        iterators.erase(itername);
+    }
+
+    if (!iterator_drop_list.empty()) {
+        save();
+    }
+}
+
 void Database::collect_garbage(
     std::set<DatabaseSnapshot *> &working_snapshots) {
     std::set<std::string> required_datasets;
@@ -207,6 +235,8 @@ void Database::collect_garbage(
     for (const auto &ds : drop_list) {
         destroy_dataset(ds);
     }
+
+    collect_stale_iterators();
 }
 
 void Database::commit_task(const TaskSpec &spec,

--- a/libursa/Database.cpp
+++ b/libursa/Database.cpp
@@ -183,7 +183,8 @@ void Database::destroy_dataset(const std::string &dsname) {
 }
 
 void Database::collect_stale_iterators() {
-    uint64_t iterator_gc_seconds = config_.get(ConfigKey::iterator_gc_seconds());
+    uint64_t iterator_gc_seconds =
+        config_.get(ConfigKey::iterator_gc_seconds());
     if (iterator_gc_seconds == 0) {
         // Zero means that GC is disabled.
         return;

--- a/libursa/Database.h
+++ b/libursa/Database.h
@@ -30,6 +30,11 @@ class Database {
 
     bool can_acquire(const DatabaseLock &newlock) const;
 
+    // Find and remove all stale iterators from disk.
+    // Iterators older than iterator_gc_seconds are removed.
+    // This may cause database to be saved.
+    void collect_stale_iterators();
+
    public:
     explicit Database(const std::string &fname);
 

--- a/libursa/DatabaseConfig.h
+++ b/libursa/DatabaseConfig.h
@@ -37,7 +37,7 @@ class ConfigKey {
     static std::vector<ConfigKey> available() {
         return {
             query_max_edge(),     query_max_ngram(), database_workers(),
-            merge_max_datasets(), merge_max_files(),
+            merge_max_datasets(), merge_max_files(), iterator_gc_seconds(),
         };
     }
 
@@ -57,6 +57,18 @@ class ConfigKey {
     // fast, use many wildcards, but have many false positives, increase to 256.
     const static ConfigKey query_max_ngram() {
         return ConfigKey("query_max_ngram", 16, 1, 16777215);
+    }
+
+    // Iterators can be used to keep intermediate results of queries on disk,
+    // instead of returning them all immediately as a part of response. But
+    // sometimes they're left behind when client don't read them to the end
+    // or drop them properly. So the database will remove all stale iterators
+    // if they're not accessed for a long time.
+    // Setting this value to zero disables iterator GC completely.
+    // Recommendation: The default value of 1 day makes sense. Change to a
+    // zero if you don't want to clean up stale iterators.
+    const static ConfigKey iterator_gc_seconds() {
+        return ConfigKey("iterator_gc_seconds", 60*60*24, 0, 4294967295);
     }
 
     // How many tasks can be processed at once? The default 4 is a very

--- a/libursa/DatabaseConfig.h
+++ b/libursa/DatabaseConfig.h
@@ -68,7 +68,7 @@ class ConfigKey {
     // Recommendation: The default value of 1 day makes sense. Change to a
     // zero if you don't want to clean up stale iterators.
     const static ConfigKey iterator_gc_seconds() {
-        return ConfigKey("iterator_gc_seconds", 60*60*24, 0, 4294967295);
+        return ConfigKey("iterator_gc_seconds", 60 * 60 * 24, 0, 4294967295);
     }
 
     // How many tasks can be processed at once? The default 4 is a very

--- a/libursa/DatabaseUpgrader.cpp
+++ b/libursa/DatabaseUpgrader.cpp
@@ -14,8 +14,7 @@ json read_json(const fs::path &root, std::string_view path) {
     std::ifstream db_file(root / path, std::ifstream::binary);
 
     if (db_file.fail()) {
-        throw std::runtime_error("Failed to open database file " +
-                                 std::string(root) + " " + std::string(path));
+        throw std::runtime_error("Failed to open database file ");
     }
 
     json db_json;

--- a/libursa/DatabaseUpgrader.cpp
+++ b/libursa/DatabaseUpgrader.cpp
@@ -10,11 +10,12 @@ std::string extract_version(const json &dbjson) {
     return dbjson.value("version", "1.0.0");
 }
 
-json read_json(std::string_view path) {
-    std::ifstream db_file(std::string(path), std::ifstream::binary);
+json read_json(const fs::path &root, std::string_view path) {
+    std::ifstream db_file(root / path, std::ifstream::binary);
 
     if (db_file.fail()) {
-        throw std::runtime_error("Failed to open database file");
+        throw std::runtime_error("Failed to open database file " +
+                                 std::string(root) + " " + std::string(path));
     }
 
     json db_json;
@@ -27,7 +28,7 @@ json read_json(std::string_view path) {
     return db_json;
 }
 
-void save_json(const fs::path &root, std::string_view path,
+void save_json(const fs::path &root, std::string_view filename,
                const json &dbjson) {
     std::string tmp_db_name = root / ("upgrade." + random_hex_string(8));
     std::ofstream db_file;
@@ -36,9 +37,11 @@ void save_json(const fs::path &root, std::string_view path,
     db_file << std::setw(4) << dbjson << std::endl;
     db_file.flush();
     db_file.close();
-    fs::rename(tmp_db_name, path);
+    fs::rename(tmp_db_name, root / filename);
 }
 
+// What changed: "max_mem_size" config options was removed, and
+// iterators were added to the db.
 void upgrade_v1_0_0(json *dbjson) {
     json &db = *dbjson;
     db["version"] = "1.3.2";
@@ -56,12 +59,27 @@ void upgrade_v1_0_0(json *dbjson) {
     }
 }
 
+// What changed: iterator GC was added, and all iterators now
+// know when they were last read. To avoid deleting all old iterators,
+// we set last read time to the current timestamp.
+void upgrade_v1_3_2(const fs::path &root, json *dbjson) {
+    json &db = *dbjson;
+    db["version"] = "1.5.0";
+    for (const auto iter : db["iterators"].items()) {
+        std::string filename{iter.value()};
+        json iterjson = read_json(root, filename);
+        iterjson["last_read_timestamp"] = std::time(nullptr);
+        save_json(root, filename, iterjson);
+    }
+}
+
 void migrate_version(std::string_view path) {
-    std::string most_recent = "1.3.2";
+    std::string most_recent = "1.5.0";
     std::string prev_version;
     auto db_root = fs::path(path).parent_path();
+    auto db_name = std::string(fs::path(path).filename());
     while (true) {
-        json db_json = std::move(read_json(path));
+        json db_json = std::move(read_json(db_root, db_name));
         std::string version = extract_version(db_json);
         if (version == prev_version) {
             spdlog::error("Upgrade procedure failed. Trying to proceed...");
@@ -76,7 +94,10 @@ void migrate_version(std::string_view path) {
         if (version == "1.0.0") {
             upgrade_v1_0_0(&db_json);
         }
+        if (version == "1.3.2") {
+            upgrade_v1_3_2(db_root, &db_json);
+        }
         prev_version = version;
-        save_json(db_root, path, db_json);
+        save_json(db_root, db_name, db_json);
     }
 }

--- a/libursa/DatabaseUpgrader.cpp
+++ b/libursa/DatabaseUpgrader.cpp
@@ -14,7 +14,7 @@ json read_json(const fs::path &root, std::string_view path) {
     std::ifstream db_file(root / path, std::ifstream::binary);
 
     if (db_file.fail()) {
-        throw std::runtime_error("Failed to open database file ");
+        throw std::runtime_error("Failed to open database file");
     }
 
     json db_json;

--- a/libursa/OnDiskIterator.cpp
+++ b/libursa/OnDiskIterator.cpp
@@ -8,12 +8,14 @@
 OnDiskIterator::OnDiskIterator(const DatabaseName &name,
                                const DatabaseName &datafile_name,
                                uint64_t total_files, uint64_t byte_offset,
-                               uint64_t file_offset)
+                               uint64_t file_offset,
+                               std::time_t last_read_time)
     : name(name),
       datafile_name(datafile_name),
       total_files(total_files),
       byte_offset(byte_offset),
-      file_offset(file_offset) {}
+      file_offset(file_offset),
+      last_read_time(last_read_time) {}
 
 void write_itermeta(const DatabaseName &target, uint64_t byte_offset,
                     uint64_t file_offset, uint64_t total_files,
@@ -28,6 +30,7 @@ void write_itermeta(const DatabaseName &target, uint64_t byte_offset,
     iter_json["file_offset"] = file_offset;
     iter_json["total_files"] = total_files;
     iter_json["backing_storage"] = backing_storage.get_filename();
+    iter_json["last_read_timestamp"] = std::time(nullptr);
 
     iter_file << std::setw(4) << iter_json << std::endl;
     iter_file.close();
@@ -54,9 +57,12 @@ OnDiskIterator OnDiskIterator::load(const DatabaseName &name) {
     uint64_t file_offset = j["file_offset"];
     uint64_t total_files = j["total_files"];
     auto datafile_name = name.derive("iterator", j["backing_storage"]);
+    // Handle iterators from ursadb <= 1.5 by using timestamp way
+    // in the past (note: this will cause GC to remove them).
+    uint64_t last_read_timestamp = j.value("last_read_timestamp", 0);
 
     return OnDiskIterator(name, datafile_name, total_files, byte_offset,
-                          file_offset);
+                          file_offset, last_read_timestamp);
 }
 
 void OnDiskIterator::pop(int count, std::vector<std::string> *out) {

--- a/libursa/OnDiskIterator.cpp
+++ b/libursa/OnDiskIterator.cpp
@@ -56,9 +56,7 @@ OnDiskIterator OnDiskIterator::load(const DatabaseName &name) {
     uint64_t file_offset = j["file_offset"];
     uint64_t total_files = j["total_files"];
     auto datafile_name = name.derive("iterator", j["backing_storage"]);
-    // Handle iterators from ursadb <= 1.5 by using timestamp way
-    // in the past (note: this will cause GC to remove them).
-    uint64_t last_read_timestamp = j.value("last_read_timestamp", 0);
+    uint64_t last_read_timestamp = j["last_read_timestamp"];
 
     return OnDiskIterator(name, datafile_name, total_files, byte_offset,
                           file_offset, last_read_timestamp);

--- a/libursa/OnDiskIterator.cpp
+++ b/libursa/OnDiskIterator.cpp
@@ -8,8 +8,7 @@
 OnDiskIterator::OnDiskIterator(const DatabaseName &name,
                                const DatabaseName &datafile_name,
                                uint64_t total_files, uint64_t byte_offset,
-                               uint64_t file_offset,
-                               std::time_t last_read_time)
+                               uint64_t file_offset, std::time_t last_read_time)
     : name(name),
       datafile_name(datafile_name),
       total_files(total_files),

--- a/libursa/OnDiskIterator.h
+++ b/libursa/OnDiskIterator.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <ctime>
+
 #include "DatabaseName.h"
 
 class OnDiskIterator {
@@ -8,10 +10,13 @@ class OnDiskIterator {
     uint64_t total_files;
     uint64_t byte_offset;
     uint64_t file_offset;
+    std::time_t last_read_time;
+
 
     OnDiskIterator(const DatabaseName &name, const DatabaseName &datafile_name,
                    uint64_t total_files, uint64_t byte_offset,
-                   uint64_t file_offset);
+                   uint64_t file_offset,
+                   std::time_t last_read_time);
 
    public:
     const DatabaseName &get_name() const { return name; }
@@ -22,10 +27,9 @@ class OnDiskIterator {
     void drop();
 
     uint64_t get_byte_offset() const { return byte_offset; }
-
     uint64_t get_file_offset() const { return file_offset; }
-
     uint64_t get_total_files() const { return total_files; }
+    std::time_t get_last_read_time() const { return last_read_time; }
 
     void update_offset(uint64_t new_bytes, uint64_t new_files) {
         byte_offset = new_bytes;

--- a/libursa/OnDiskIterator.h
+++ b/libursa/OnDiskIterator.h
@@ -12,11 +12,9 @@ class OnDiskIterator {
     uint64_t file_offset;
     std::time_t last_read_time;
 
-
     OnDiskIterator(const DatabaseName &name, const DatabaseName &datafile_name,
                    uint64_t total_files, uint64_t byte_offset,
-                   uint64_t file_offset,
-                   std::time_t last_read_time);
+                   uint64_t file_offset, std::time_t last_read_time);
 
    public:
     const DatabaseName &get_name() const { return name; }

--- a/libursa/Version.h.in
+++ b/libursa/Version.h.in
@@ -4,7 +4,7 @@
 
 // This is is a *file format version*, not necessarily equal to the db version.
 // It looks similar to the db version to make it easy to correlate them.
-constexpr std::string_view ursadb_format_version = "1.3.2";
+constexpr std::string_view ursadb_format_version = "1.5.0";
 
 constexpr std::string_view ursadb_version = "@PROJECT_VERSION@";
 constexpr std::string_view ursadb_commit = "@COMMIT_HASH@";

--- a/teste2e/test_format_upgrades.py
+++ b/teste2e/test_format_upgrades.py
@@ -92,7 +92,7 @@ def test_new_database(ursadb: UrsadbTestContext):
         "config": {},
         "datasets": [],
         "iterators": {},
-        "version": "1.3.2",
+        "version": "1.5.0",
     }
 
 
@@ -108,7 +108,7 @@ def test_upgrade_from_v1_0_0_clean():
         "config": {},
         "datasets": [],
         "iterators": {},
-        "version": "1.3.2",
+        "version": "1.5.0",
     }
 
 
@@ -124,5 +124,5 @@ def test_upgrade_from_v1_0_0_dirty():
         "config": {},
         "datasets": ["set.72fa9b58.db.ursa", "set.964c6279.db.ursa"],
         "iterators": {"00c16214": "itermeta.00c16214.db.ursa"},
-        "version": "1.3.2",
+        "version": "1.5.0",
     }


### PR DESCRIPTION
Clean up old iterators from disk after some time (by default: one day).

**Warning** - this will remove all existing iterators when the database version is updated. This shouldn't be a huge problem, but it will break any long running queries using iterators (for example, from mquery). That's because default "age" of iterator is very old.
There are two ways to fix this:

- Use current time as a default age of iterator - wouldn't work, because iterators that are not read won't ever get updated time and be GCed. And these are precisely iterators we want to remove!
- By default disable iterator GC. But I want GC to be enabled by default! I don't want to ship database broken by default and require users to change the config.

There is one workaround for people that really care - they can manually edit main database json file and add a config key `iterator_gc_seconds` with value `0`.

Fixes #207