### PR TITLE
Lower iopriority when indexing to IDLE

### DIFF
--- a/libursa/CMakeLists.txt
+++ b/libursa/CMakeLists.txt
@@ -29,6 +29,8 @@ add_library(
     IndexBuilder.h
     Indexer.cpp
     Indexer.h
+    IoPrio.cpp
+    IoPrio.h
     Json.h
     MemMap.cpp
     MemMap.h

--- a/libursa/Daemon.cpp
+++ b/libursa/Daemon.cpp
@@ -17,6 +17,7 @@
 #include "Command.h"
 #include "Database.h"
 #include "DatasetBuilder.h"
+#include "IoPrio.h"
 #include "OnDiskDataset.h"
 #include "QueryParser.h"
 #include "Responses.h"
@@ -62,6 +63,8 @@ Response execute_command(const IteratorPopCommand &cmd, Task *task,
 
 Response execute_command(const IndexFromCommand &cmd, Task *task,
                          const DatabaseSnapshot *snap) {
+    IoPriority(IoPriorityClass::Idle);
+
     const auto &path_list_fname = cmd.get_path_list_fname();
 
     std::vector<std::string> paths;
@@ -95,6 +98,8 @@ Response execute_command(const IndexFromCommand &cmd, Task *task,
 
 Response execute_command(const IndexCommand &cmd, Task *task,
                          const DatabaseSnapshot *snap) {
+    IoPriority(IoPriorityClass::Idle);
+
     if (cmd.ensure_unique()) {
         snap->recursive_index_paths(task, cmd.get_index_types(), cmd.taints(),
                                     cmd.get_paths());
@@ -140,6 +145,8 @@ Response execute_command(const ConfigSetCommand &cmd, Task *task,
 
 Response execute_command(const ReindexCommand &cmd, Task *task,
                          const DatabaseSnapshot *snap) {
+    IoPriority(IoPriorityClass::Idle);
+
     const std::string &dataset_id = cmd.dataset_id();
     snap->reindex_dataset(task, cmd.get_index_types(), dataset_id);
 
@@ -148,6 +155,8 @@ Response execute_command(const ReindexCommand &cmd, Task *task,
 
 Response execute_command([[maybe_unused]] const CompactCommand &cmd, Task *task,
                          const DatabaseSnapshot *snap) {
+    IoPriority(IoPriorityClass::Idle);
+
     snap->compact_locked_datasets(task);
     return Response::ok();
 }
@@ -251,6 +260,8 @@ std::vector<DatabaseLock> acquire_locks(
 
 std::vector<DatabaseLock> acquire_locks(const CompactCommand &cmd,
                                         const DatabaseSnapshot *snap) {
+    IoPriority(IoPriorityClass::Idle);
+
     std::vector<std::string> to_lock;
     if (cmd.get_type() == CompactType::Smart) {
         to_lock = snap->compact_smart_candidates();

--- a/libursa/Daemon.cpp
+++ b/libursa/Daemon.cpp
@@ -63,7 +63,7 @@ Response execute_command(const IteratorPopCommand &cmd, Task *task,
 
 Response execute_command(const IndexFromCommand &cmd, Task *task,
                          const DatabaseSnapshot *snap) {
-    IoPriority(IoPriorityClass::Idle);
+    auto idle_guard = IoPriority(IoPriorityClass::Idle);
 
     const auto &path_list_fname = cmd.get_path_list_fname();
 
@@ -98,7 +98,7 @@ Response execute_command(const IndexFromCommand &cmd, Task *task,
 
 Response execute_command(const IndexCommand &cmd, Task *task,
                          const DatabaseSnapshot *snap) {
-    IoPriority(IoPriorityClass::Idle);
+    auto idle_guard = IoPriority(IoPriorityClass::Idle);
 
     if (cmd.ensure_unique()) {
         snap->recursive_index_paths(task, cmd.get_index_types(), cmd.taints(),
@@ -145,7 +145,7 @@ Response execute_command(const ConfigSetCommand &cmd, Task *task,
 
 Response execute_command(const ReindexCommand &cmd, Task *task,
                          const DatabaseSnapshot *snap) {
-    IoPriority(IoPriorityClass::Idle);
+    auto idle_guard = IoPriority(IoPriorityClass::Idle);
 
     const std::string &dataset_id = cmd.dataset_id();
     snap->reindex_dataset(task, cmd.get_index_types(), dataset_id);
@@ -155,7 +155,7 @@ Response execute_command(const ReindexCommand &cmd, Task *task,
 
 Response execute_command([[maybe_unused]] const CompactCommand &cmd, Task *task,
                          const DatabaseSnapshot *snap) {
-    IoPriority(IoPriorityClass::Idle);
+    auto idle_guard = IoPriority(IoPriorityClass::Idle);
 
     snap->compact_locked_datasets(task);
     return Response::ok();
@@ -260,7 +260,7 @@ std::vector<DatabaseLock> acquire_locks(
 
 std::vector<DatabaseLock> acquire_locks(const CompactCommand &cmd,
                                         const DatabaseSnapshot *snap) {
-    IoPriority(IoPriorityClass::Idle);
+    auto idle_guard = IoPriority(IoPriorityClass::Idle);
 
     std::vector<std::string> to_lock;
     if (cmd.get_type() == CompactType::Smart) {

--- a/libursa/IoPrio.cpp
+++ b/libursa/IoPrio.cpp
@@ -21,11 +21,28 @@ enum {
     IOPRIO_WHO_USER,
 };
 
+enum {
+    IOPRIO_CLASS_NONE,
+    IOPRIO_CLASS_RT,
+    IOPRIO_CLASS_BE,
+    IOPRIO_CLASS_IDLE,
+};
+
+constexpr int IOPRIO_CLASS_SHIFT = 13;
+
 // Change ioprio for the current process, and save the current PID.
 IoPriority::IoPriority(IoPriorityClass ioprio) {
     _old_pid = getpid();
     _old_ioprio = ioprio_get(IOPRIO_WHO_PROCESS, _old_pid);
-    ioprio_set(IOPRIO_WHO_PROCESS, _old_pid, (int)ioprio);
+    int ioprio_value = 0;
+    if (ioprio == IoPriorityClass::BestEffort) {
+        ioprio_value = (IOPRIO_CLASS_BE << IOPRIO_CLASS_SHIFT) | 0;
+    } else if (ioprio == IoPriorityClass::Idle) {
+        ioprio_value = (IOPRIO_CLASS_IDLE << IOPRIO_CLASS_SHIFT) | 7;
+    } else {
+        throw std::runtime_error("Invalid IoPriorityClass");
+    }
+    ioprio_set(IOPRIO_WHO_PROCESS, _old_pid, ioprio_value);
 }
 
 // Restore ioprio for the current process (and check it's still the same PID).

--- a/libursa/IoPrio.cpp
+++ b/libursa/IoPrio.cpp
@@ -1,0 +1,40 @@
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include "IoPrio.h"
+#include "spdlog/spdlog.h"
+
+// Reference: https://www.kernel.org/doc/html/latest/block/ioprio.html
+
+static inline int ioprio_set(int which, int who, int ioprio) {
+    return syscall(__NR_ioprio_set, which, who, ioprio);
+}
+
+static inline int ioprio_get(int which, int who) {
+    return syscall(__NR_ioprio_get, which, who);
+}
+
+// Copied from include/linux/ioprio.h
+enum {
+    IOPRIO_WHO_PROCESS = 1,
+    IOPRIO_WHO_PGRP,
+    IOPRIO_WHO_USER,
+};
+
+// Change ioprio for the current process, and save the current PID.
+IoPriority::IoPriority(IoPriorityClass ioprio) {
+    _old_pid = getpid();
+    _old_ioprio = ioprio_get(IOPRIO_WHO_PROCESS, _old_pid);
+    ioprio_set(IOPRIO_WHO_PROCESS, _old_pid, (int)ioprio);
+}
+
+// Restore ioprio for the current process (and check it's still the same PID).
+IoPriority::~IoPriority() {
+    pid_t current_pid = getpid();
+    ioprio_set(IOPRIO_WHO_PROCESS, current_pid, _old_ioprio);
+    if (current_pid != _old_pid) {
+        // This should not happen. Maybe we should just raise an error,
+        // but instead let's just try to the right thing and keep going.
+        spdlog::error("Thread forked in IoPriority context.");
+    }
+}

--- a/libursa/IoPrio.h
+++ b/libursa/IoPrio.h
@@ -1,0 +1,28 @@
+#include <sys/syscall.h>
+#include <unistd.h>
+
+// Copied from include/linux/ioprio.h
+enum {
+    IOPRIO_CLASS_NONE,
+    IOPRIO_CLASS_RT,
+    IOPRIO_CLASS_BE,
+    IOPRIO_CLASS_IDLE,
+};
+
+// Strongly typed wrapper for IOPRIO enum in the Linux kernel.
+enum class IoPriorityClass {
+    Idle = IOPRIO_CLASS_IDLE,
+    BestEffort = IOPRIO_CLASS_BE
+    // IOPRIO_CLASS_RT not needed, and not defined intentionally.
+};
+
+// RAII class for setting the current thread's IO priority.
+// Will change thread's ioprio in the constructor, and restore in destructor.
+class IoPriority {
+    int _old_ioprio;
+    pid_t _old_pid;
+
+   public:
+    IoPriority(IoPriorityClass ioprio);
+    ~IoPriority();
+};

--- a/libursa/IoPrio.h
+++ b/libursa/IoPrio.h
@@ -1,20 +1,8 @@
 #include <sys/syscall.h>
 #include <unistd.h>
 
-// Copied from include/linux/ioprio.h
-enum {
-    IOPRIO_CLASS_NONE,
-    IOPRIO_CLASS_RT,
-    IOPRIO_CLASS_BE,
-    IOPRIO_CLASS_IDLE,
-};
-
 // Strongly typed wrapper for IOPRIO enum in the Linux kernel.
-enum class IoPriorityClass {
-    Idle = IOPRIO_CLASS_IDLE,
-    BestEffort = IOPRIO_CLASS_BE
-    // IOPRIO_CLASS_RT not needed, and not defined intentionally.
-};
+enum class IoPriorityClass { Idle, BestEffort };
 
 // RAII class for setting the current thread's IO priority.
 // Will change thread's ioprio in the constructor, and restore in destructor.


### PR DESCRIPTION
Draft, because this is not tested yet, and I'm not 100% sure this actually solves our problem.

This PR adds a class called IoPriority, and uses it to lower the process' ioprio when doing background tasks, like indexing and compacting.

Fixes #212