### PR TITLE
Refactor primitive queries into AND of atoms

### DIFF
--- a/libursa/CMakeLists.txt
+++ b/libursa/CMakeLists.txt
@@ -80,19 +80,4 @@ target_clangformat_setup(ursa)
 # See: https://github.com/zeromq/cppzmq/issues/330
 target_compile_options(ursa PUBLIC -Wno-deprecated-declarations)
 
-find_package(Git)
-if(Git_FOUND)
-    execute_process(
-        COMMAND
-        # get commit shorthash
-        ${GIT_EXECUTABLE} rev-parse --short HEAD
-        OUTPUT_VARIABLE
-        COMMIT_HASH
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-else()
-    message(WARNING "Git not found. Hash info won't be available")
-    set(COMMIT_HASH "(unknown commit)")
-endif()
-
 configure_file(Version.h.in ${PROJECT_BINARY_DIR}/generated/Version.h)

--- a/libursa/Query.cpp
+++ b/libursa/Query.cpp
@@ -123,8 +123,8 @@ QToken filter_qtoken(const QToken &token, uint32_t off,
 // For primitive queries, find a minimal covering set of ngram queries and
 // return it. If there are multiple disconnected components, AND them.
 // For example, "abcde\x??efg" will return abcd & bcde & efg
-Query plan_qstring(
-    const std::unordered_set<IndexType> &types_to_query, const QString &value) {
+Query plan_qstring(const std::unordered_set<IndexType> &types_to_query,
+                   const QString &value) {
     std::vector<Query> plan;
 
     bool has_gram3 = types_to_query.count(IndexType::GRAM3) != 0;

--- a/libursa/Query.h
+++ b/libursa/Query.h
@@ -43,14 +43,12 @@ using QueryPrimitive =
 class Query {
    public:
     explicit Query(PrimitiveQuery ngram)
-        : type(QueryType::PRIMITIVE),
-          ngram(ngram),
-          value() {}
+        : type(QueryType::PRIMITIVE), ngram(ngram), value() {}
     explicit Query(QString &&qstr);
     explicit Query(uint32_t count, std::vector<Query> &&queries);
     explicit Query(const QueryType &type, std::vector<Query> &&queries);
     Query(Query &&other) = default;
-    Query& operator=(Query&&) = default;
+    Query &operator=(Query &&) = default;
 
     const std::vector<Query> &as_queries() const;
     const QString &as_value() const;

--- a/libursa/Query.h
+++ b/libursa/Query.h
@@ -41,17 +41,16 @@ using QueryPrimitive =
 // planned (using a plan() method). At this point query decides which ngrams
 // will actually be checked.
 class Query {
-   private:
-    explicit Query(std::vector<PrimitiveQuery> &&query_plan)
-        : type(QueryType::PRIMITIVE),
-          query_plan(std::move(query_plan)),
-          value() {}
-
    public:
+    explicit Query(PrimitiveQuery ngram)
+        : type(QueryType::PRIMITIVE),
+          ngram(ngram),
+          value() {}
     explicit Query(QString &&qstr);
     explicit Query(uint32_t count, std::vector<Query> &&queries);
     explicit Query(const QueryType &type, std::vector<Query> &&queries);
     Query(Query &&other) = default;
+    Query& operator=(Query&&) = default;
 
     const std::vector<Query> &as_queries() const;
     const QString &as_value() const;
@@ -66,9 +65,10 @@ class Query {
 
    private:
     QueryType type;
-    // used for QueryType::PRIMITIVE
-    QString value;                           // before plan()
-    std::vector<PrimitiveQuery> query_plan;  // after plan()
+    // used for QueryType::PRIMITIVE before plan()
+    QString value;
+    // used for QueryType::PRIMITIVE after plan(). Initial value arbitrary.
+    PrimitiveQuery ngram = PrimitiveQuery(IndexType::GRAM3, 0);
     // used for QueryType::MIN_OF
     uint32_t count;
     // used for QueryType::AND/OR/MIN_OF

--- a/libursa/Version.h.in
+++ b/libursa/Version.h.in
@@ -6,7 +6,6 @@
 // It looks similar to the db version to make it easy to correlate them.
 constexpr std::string_view ursadb_format_version = "1.5.0";
 
-constexpr std::string_view ursadb_version = "@PROJECT_VERSION@";
-constexpr std::string_view ursadb_commit = "@COMMIT_HASH@";
-constexpr std::string_view ursadb_version_string =
-    "@PROJECT_VERSION@+@COMMIT_HASH@";
+// Project version.
+// Consider updating the version tag when doing PRs.
+constexpr std::string_view ursadb_version_string = "@PROJECT_VERSION@+primitives";

--- a/libursa/Version.h.in
+++ b/libursa/Version.h.in
@@ -8,4 +8,5 @@ constexpr std::string_view ursadb_format_version = "1.5.0";
 
 // Project version.
 // Consider updating the version tag when doing PRs.
-constexpr std::string_view ursadb_version_string = "@PROJECT_VERSION@+primitives";
+constexpr std::string_view ursadb_version_string =
+    "@PROJECT_VERSION@+primitives";


### PR DESCRIPTION
Instead of having a dedicated query type to AND of tokens, we can just create a query type for tokens and use AND query type with them. This makes optimization easier later.

This PR also changes the way build versions work (the current method with git revision parsing was too brittle, and didn't work for me).