### PR TITLE
opt3: deduplicate_primitives

### DIFF
--- a/libursa/Query.cpp
+++ b/libursa/Query.cpp
@@ -80,8 +80,14 @@ const QString &Query::as_value() const {
     if (type != QueryType::PRIMITIVE) {
         throw std::runtime_error("This query doesn\'t have any value.");
     }
-
     return value;
+}
+
+PrimitiveQuery Query::as_ngram() const {
+    if (type != QueryType::PRIMITIVE) {
+        throw std::runtime_error("This query doesn\'t contain a ngram.");
+    }
+    return ngram;
 }
 
 std::string Query::as_string_repr() const {

--- a/libursa/Query.h
+++ b/libursa/Query.h
@@ -54,6 +54,7 @@ class Query {
     std::vector<Query> &as_queries();
     const QString &as_value() const;
     uint32_t as_count() const;
+    PrimitiveQuery as_ngram() const;
     std::string as_string_repr() const;
     const QueryType &get_type() const;
     bool operator==(const Query &other) const;

--- a/libursa/Version.h.in
+++ b/libursa/Version.h.in
@@ -9,5 +9,5 @@ constexpr std::string_view ursadb_format_version = "1.5.0";
 // Project version.
 // Consider updating the version tag when doing PRs.
 // clang-format off
-constexpr std::string_view ursadb_version_string = "@PROJECT_VERSION@+opt2";
+constexpr std::string_view ursadb_version_string = "@PROJECT_VERSION@+opt3";
 // clang-format on


### PR DESCRIPTION
```
// This optimization gets rid of duplicated primitive queries.
// AND(a, a, a, a, b, b) == AND(a, b)
// This also applies to OR(), but it'll happen very rarely.
```