### PR TITLE
opt4: simplify_minof

### DIFF
--- a/libursa/Version.h.in
+++ b/libursa/Version.h.in
@@ -9,5 +9,5 @@ constexpr std::string_view ursadb_format_version = "1.5.0";
 // Project version.
 // Consider updating the version tag when doing PRs.
 // clang-format off
-constexpr std::string_view ursadb_version_string = "@PROJECT_VERSION@+opt3";
+constexpr std::string_view ursadb_version_string = "@PROJECT_VERSION@+opt4";
 // clang-format on


### PR DESCRIPTION
```
// Minof is the slowest operation, so replace it by others if possible.
// This may also enable other optimizations to take place.
// MIN 5 OF (a, b, c, d, e) --> AND(a, b, c, d, e)
// MIN 1 OF (a, b, c, d, e) --> OR(a, b, c, d, e)
// MIN 0 OF (a, b, c, d, e) --> everything()
```