### PR TITLE
opt5: propagate_degenerate_queries

### DIFF
--- a/libursa/Version.h.in
+++ b/libursa/Version.h.in
@@ -9,5 +9,5 @@ constexpr std::string_view ursadb_format_version = "1.5.0";
 // Project version.
 // Consider updating the version tag when doing PRs.
 // clang-format off
-constexpr std::string_view ursadb_version_string = "@PROJECT_VERSION@+opt4";
+constexpr std::string_view ursadb_version_string = "@PROJECT_VERSION@+opt5";
 // clang-format on


### PR DESCRIPTION
```
// Propagate 'everything' results through the query. For example,
// if we know that C is everything, we immediately know OR(a, b, C)
// OR(AND(), b, c) --> AND()
// MIN 3 OF (AND(), b, c, d) --> MIN 2 OF (b, c, d)
```