### PR TITLE
opt7: prefetching

### DIFF
--- a/libursa/OnDiskDataset.cpp
+++ b/libursa/OnDiskDataset.cpp
@@ -83,6 +83,13 @@ QueryResult OnDiskDataset::query(const Query &query,
             }
             throw std::runtime_error("Unexpected ngram type in query");
         },
+        [this, &seen](PrimitiveQuery primitive) {
+            for (auto &ndx : indices) {
+                if (ndx.index_type() == primitive.itype) {
+                    ndx.prefetch(primitive.trigram);
+                }
+            }
+        },
         counters);
 }
 

--- a/libursa/OnDiskIndex.cpp
+++ b/libursa/OnDiskIndex.cpp
@@ -60,6 +60,12 @@ QueryResult OnDiskIndex::query(TriGram trigram, QueryCounters *counters) const {
     return QueryResult(std::move(query_primitive(trigram, &counters->reads())));
 }
 
+void OnDiskIndex::prefetch(TriGram trigram) const {
+    std::pair<uint64_t, uint64_t> offsets = get_run_offsets(trigram);
+    uint64_t length = offsets.second - offsets.first;
+    ndxfile.prefetch(length, offsets.first);
+}
+
 std::pair<uint64_t, uint64_t> OnDiskIndex::get_run_offsets(
     TriGram trigram) const {
     uint64_t ptrs[2];

--- a/libursa/OnDiskIndex.h
+++ b/libursa/OnDiskIndex.h
@@ -38,6 +38,8 @@ class OnDiskIndex {
     const fs::path &get_fpath() const { return fpath; }
     IndexType index_type() const { return ntype; }
     QueryResult query(TriGram trigram, QueryCounters *counters) const;
+    void prefetch(TriGram trigram) const;
+
     uint64_t real_size() const;
     static void on_disk_merge(const fs::path &db_base, const std::string &fname,
                               IndexType merge_type,

--- a/libursa/Query.h
+++ b/libursa/Query.h
@@ -33,6 +33,8 @@ class PrimitiveQuery {
 using QueryPrimitive =
     std::function<QueryResult(PrimitiveQuery, QueryCounters *counter)>;
 
+using PrefetchFunc = std::function<void(PrimitiveQuery)>;
+
 // Query represents the query as provided by the user.
 // Query can contain subqueries (using AND/OR/MINOF) or be a literal query.
 // There are actually two types of literal query objects - "plain" and
@@ -60,10 +62,14 @@ class Query {
     bool operator==(const Query &other) const;
 
     QueryResult run(const QueryPrimitive &primitive,
+                    const PrefetchFunc &prefetch,
                     QueryCounters *counters) const;
     Query plan(const std::unordered_set<IndexType> &types_to_query) const;
 
    private:
+    void prefetch(int from_index, int howmany, bool only_last,
+                  const PrefetchFunc &prefetch) const;
+
     QueryType type;
     // used for QueryType::PRIMITIVE before plan()
     QString value;

--- a/libursa/RawFile.cpp
+++ b/libursa/RawFile.cpp
@@ -44,6 +44,10 @@ void RawFile::pread(void *buf, size_t to_read, off_t offset) const {
     }
 }
 
+void RawFile::prefetch(size_t size, off_t offset) const {
+    ::posix_fadvise(fd, offset, size, POSIX_FADV_WILLNEED);
+}
+
 template <typename T>
 void RawFile::write(const T *buf, size_t count) {
     const auto *buf_raw = reinterpret_cast<const char *>(buf);

--- a/libursa/RawFile.h
+++ b/libursa/RawFile.h
@@ -13,6 +13,7 @@ class RawFile {
 
     uint64_t size() const;
     void pread(void *buf, size_t to_read, off_t offset) const;
+    void prefetch(size_t size, off_t offse) const;
 
     template <typename T>
     void write(const T *buf, size_t count);

--- a/libursa/Version.h.in
+++ b/libursa/Version.h.in
@@ -9,5 +9,5 @@ constexpr std::string_view ursadb_format_version = "1.5.0";
 // Project version.
 // Consider updating the version tag when doing PRs.
 // clang-format off
-constexpr std::string_view ursadb_version_string = "@PROJECT_VERSION@+opt6";
+constexpr std::string_view ursadb_version_string = "@PROJECT_VERSION@+opt7";
 // clang-format on


### PR DESCRIPTION
```
// Prefetch the next `howmany` ngrams.
// This doesn't recurse into other queries. It's not a big problem,
// because all primitives that we can fetch are in long AND sequences.
// But in the future we may consider improving this.
```