### PR TITLE
opt9: batch vle processing

### DIFF
--- a/libursa/SortedRun.cpp
+++ b/libursa/SortedRun.cpp
@@ -51,7 +51,7 @@ void SortedRun::do_or(SortedRun &other) {
     other.decompress();
     std::vector<FileId> new_results;
     std::set_union(other.begin(), other.end(), begin(), end(),
-                    std::back_inserter(new_results));
+                   std::back_inserter(new_results));
     std::swap(new_results, sequence_);
 }
 
@@ -91,7 +91,8 @@ bool IntersectionHelper::step_by_8() {
         return true;
     }
 
-    for (uint8_t *end = run_it_ + BATCH_SIZE; run_it_ < end && seq_it_ < seq_end_;) {
+    for (uint8_t *end = run_it_ + BATCH_SIZE;
+         run_it_ < end && seq_it_ < seq_end_;) {
         uint32_t next = prev_ + *run_it_ + 1;
         if (next < *seq_it_) {
             prev_ = next;
@@ -132,8 +133,8 @@ void SortedRun::do_and(SortedRun &other) {
         helper.intersect();
         new_end = begin() + helper.result_size();
     } else {
-        new_end = std::set_intersection(
-            other.begin(), other.end(), begin(), end(), begin());
+        new_end = std::set_intersection(other.begin(), other.end(), begin(),
+                                        end(), begin());
     }
     sequence_.erase(new_end, end());
 }

--- a/libursa/SortedRun.h
+++ b/libursa/SortedRun.h
@@ -1,5 +1,6 @@
-#include "Core.h"
 #include <emmintrin.h>
+
+#include "Core.h"
 
 uint32_t run_read(uint8_t *pos);
 uint8_t *run_forward(uint8_t *pos);
@@ -19,7 +20,13 @@ class IntersectionHelper {
 
    public:
     IntersectionHelper(std::vector<uint32_t> *seq, std::vector<uint8_t> *run)
-    :run_it_(run->data()), run_end_(run->data() + run->size()), prev_(-1), seq_start_(seq->data()), seq_it_(seq->data()), seq_end_(seq->data() + seq->size()), seq_out_(seq->data()) {}
+        : run_it_(run->data()),
+          run_end_(run->data() + run->size()),
+          prev_(-1),
+          seq_start_(seq->data()),
+          seq_it_(seq->data()),
+          seq_end_(seq->data() + seq->size()),
+          seq_out_(seq->data()) {}
 
     size_t result_size() const { return seq_out_ - seq_start_; }
     void intersect();

--- a/libursa/Version.h.in
+++ b/libursa/Version.h.in
@@ -9,5 +9,5 @@ constexpr std::string_view ursadb_format_version = "1.5.0";
 // Project version.
 // Consider updating the version tag when doing PRs.
 // clang-format off
-constexpr std::string_view ursadb_version_string = "@PROJECT_VERSION@+opt8";
+constexpr std::string_view ursadb_version_string = "@PROJECT_VERSION@+opt9";
 // clang-format on


### PR DESCRIPTION
Optimize ANDing uncompressed and compressed sorted runs:

```
// Performance critical method. As of the current version, in some tests,
// more than half of the time is spent ANDing decompressed and compressed runs.
// We expect the compressed set to be large, and sequence to be short.
```

Unfortunately, the fast-case code is significantly ugly, but the speedup is worth it (AND gets almost 200% faster, and this transfers to almost 10% faster total time, depending on the workload [1]).

On the other hand, experiments with AVX2 were slightly disappointing - they give another 5% performance, but are even uglier and also make the code dependent on the CPU flags (so we probably need a fallback anyway). Most people on the internet manage to get a larger speedup from AVX, so this may be a skill issue. Anyway after this PR "and" stops being a bottleneck again.

Similarly, tests with SSE were maybe a bit faster (within a test margin of error) but this made code more complicated). I still believe it's possible to make this significantly faster with enogh SIMD magic, but that's good enough I guess.

[1] If you wonder why the numbers don't add up - speeding up set operations also inexplicably slows down disk reads. This is probably because of disk prefetching going on under the hood.