### PR TITLE
Release v1.5.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.9)
 project(
     ursadb
-    VERSION 1.5.1
+    VERSION 1.5.2
     LANGUAGES CXX C
 )
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,27 @@
+# Version 1.5.2 (2024-10-17)
+
+Almost exclusively performance improvements. Query speed is reduced by over 50% in tested workloads.
+
+Features:
+- Add a verbose mode (-v) that also prints debug logs (#218) 
+
+Performance:
+- Refactor  (#218) 
+- Add debug logs, including query plans (#218)
+- opt1: Flatten trivial operations (#220)
+- opt2: Inline suboperations (#221)
+- opt3: Deduplicate primitives (#222)
+- opt4: Simplify minof in some cases (#223)
+- opt5: Propagate degenerate queries (#224)
+- opt6: Reorder subqueries more optimally (#225)
+- opt7: Prefetch disk reads (#226)
+- opt8: Keep runs in compressed form for longer (#227)
+
+Correctness:
+
+Refactoring and maintenance:
+- Create a simple framework for query optimizations (#217) 
+
 # Version 1.5.1 (2023-01-04)
 
 Mostly bugfix and maintenance release:


### PR DESCRIPTION
This release consists almost exclusively of performance improvements. Query speed is reduced by over 50% in the tested workloads.

Features:
- Add a verbose mode (-v) that also prints debug logs (#218) 

Performance:
- Refactor  (#218) 
- Add debug logs, including query plans (#218)
- opt1: Flatten trivial operations (#220)
- opt2: Inline suboperations (#221)
- opt3: Deduplicate primitives (#222)
- opt4: Simplify minof in some cases (#223)
- opt5: Propagate degenerate queries (#224)
- opt6: Reorder subqueries more optimally (#225)
- opt7: Prefetch disk reads (#226)
- opt8: Keep runs in compressed form for longer (#227)

Correctness:

Refactoring and maintenance:
- Create a simple framework for query optimizations (#217) 

---

Tests were performed on a dataset consisting of 9416097 files (over 2TB of data), using a single server with a HDD RAID, and by matching all yara rules from https://github.com/Neo23x0/signature-base/ (that were not "degenerate", i.e. broken). No user-visible changes other than performance were discovered (i.e. still the same files returned). The measured time is a sum of time taken by all matching.

| Name | Time |
| --- | --- |
| opt0\_1ffe9c01 --> opt1\_1ffe9c01 |   3648s --> 3548s (-100, -2.72%)   |
| opt1\_1ffe9c01 --> opt2\_1ffe9c01 |   3548s --> 3583s (+34, +0.98%)   |
| opt2\_1ffe9c01 --> opt3\_1ffe9c01 |   3583s --> 3341s (-243, -6.76%)   |
| opt3\_1ffe9c01 --> opt4\_1ffe9c01 |   3341s --> 3164s (-178, -5.30%)   |
| opt4\_1ffe9c01 --> opt5\_1ffe9c01 |   3164s --> 3280s (+116, +3.68%)   |
| opt5\_1ffe9c01 --> opt6\_1ffe9c01 |   3280s --> 3003s (-278, -8.45%)   |
| opt6\_1ffe9c01 --> opt7\_1ffe9c01 |   3003s --> 2415s (-589, -19.58%)   |
| opt7\_1ffe9c01 --> opt8\_1ffe9c01 |   2415s --> 1635s (-781, -32.30%)   |
| opt8\_1ffe9c01 --> opt9\_1ffe9c01 |   1635s --> 1378s (-257, -15.70%)   |
| **total improvement** |   3648s --> 1378s (-2270, -62.22%)   |